### PR TITLE
Implemented utilsBackground param

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -105,3 +105,15 @@ a {
   font-weight: bold;
   border-color: #3386e0;
 }
+
+#breadcrumbs-wrapper.white {
+  background-color: #f1f1f1;
+}
+
+#breadcrumbs-wrapper.gray {
+  background-color: var(--a-bg-subtle);
+}
+
+#breadcrumbs-wrapper.transparent {
+    background-color: transparent;
+}

--- a/client/main.ts
+++ b/client/main.ts
@@ -1,6 +1,6 @@
 import "vite/modulepreload-polyfill";
 import "./main.css";
-import { Context } from "../params";
+import { Context, UtilsBackground } from "../params";
 import { FeedbackSuccess } from "../views/feedback";
 import { Breadcrumbs } from "../views/breadcrumbs";
 import { getContentData } from "./utils";
@@ -38,7 +38,8 @@ window.addEventListener("message", (e) => {
       );
       if (breadcrumbsWrapperEl) {
         breadcrumbsWrapperEl.outerHTML = Breadcrumbs({
-          breadcrumbs: e.data.payload.breadcrumbs,
+            breadcrumbs: e.data.payload.breadcrumbs,
+            utilsBackground: breadcrumbsWrapperEl.getAttribute("data-background") as UtilsBackground,
         });
       }
     }

--- a/params.ts
+++ b/params.ts
@@ -30,7 +30,10 @@ export const breadcrumbSchema = z.object({
 
 export type Breadcrumb = z.infer<typeof breadcrumbSchema>;
 
-const background = z.enum(["white", "gray", "transparent"]);
+const utilsBackground = z.enum(["white", "gray", "transparent"]);
+
+export type UtilsBackground = z.infer<typeof utilsBackground>;
+
 
 const paramsSchema = z.object({
   context: contextSchema.default("privatperson"),
@@ -50,7 +53,7 @@ const paramsSchema = z.object({
     )
     .default([]),
   breadcrumbs: z.array(breadcrumbSchema).default([]),
-  utilsBackground: background.default("transparent"),
+  utilsBackground: utilsBackground.default("transparent"),
   feedback: z.boolean().default(false),
   chatbot: z.boolean().default(true),
   chatbotVisible: z.boolean().default(false),

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -31,6 +31,6 @@ module.exports = {
         return selector;
       },
     }),
-    purgecss,
+    // purgecss,
   ],
 };

--- a/server.ts
+++ b/server.ts
@@ -116,6 +116,7 @@ app.use("/", async (req, res) => {
         innlogget: false,
         isNorwegian: true,
         breadcrumbs: req.decorator.breadcrumbs,
+        utilsBackground: req.decorator.utilsBackground,
       }),
       footer: Footer({
         texts: data.texts,

--- a/views/breadcrumbs.ts
+++ b/views/breadcrumbs.ts
@@ -1,10 +1,10 @@
-import { Breadcrumb } from "../params";
+import { Breadcrumb, UtilsBackground } from "../params";
 import { html } from "../utils";
 
-export function Breadcrumbs({ breadcrumbs }: { breadcrumbs: Breadcrumb[] }) {
+export function Breadcrumbs({ utilsBackground, breadcrumbs }: { breadcrumbs: Breadcrumb[], utilsBackground: UtilsBackground }) {
   return html`
-    <nav class="max-w-[1344px] w-full mx-auto py-3" id="breadcrumbs-wrapper">
-      <ol class="flex items-center" id="breadcrumbs-list">
+  <nav class="${`py-3 ${utilsBackground}`}" data-background="${utilsBackground}" id="breadcrumbs-wrapper">
+      <ol class="flex items-center max-w-[1344px] w-full mx-auto" id="breadcrumbs-list">
         <li>
           <a class="flex gap-1 items-center amplitude-link" href="#">
             <svg

--- a/views/header.ts
+++ b/views/header.ts
@@ -1,4 +1,4 @@
-import { Breadcrumb } from "../params";
+import { Breadcrumb, UtilsBackground } from "../params";
 import { HeaderMenuLinksData, MainMenu, html } from "@/utils";
 import { Texts } from "../texts";
 import { Breadcrumbs } from "./breadcrumbs";
@@ -13,6 +13,7 @@ export function Header({
   texts,
   innlogget,
   breadcrumbs,
+  utilsBackground
 }: {
   isNorwegian: boolean;
   mainMenu: MainMenu;
@@ -20,6 +21,7 @@ export function Header({
   headerMenuLinks: HeaderMenuLinksData;
   innlogget: boolean;
   breadcrumbs: Breadcrumb[];
+  utilsBackground: UtilsBackground
 }) {
   return html`
     <div id="header-withmenu">
@@ -133,7 +135,8 @@ export function Header({
         </div>
       </header>
       ${Breadcrumbs({
-        breadcrumbs,
+          breadcrumbs,
+          utilsBackground
       })}
     </div>
   `;


### PR DESCRIPTION
Implementerte utilsBackground parameteren.

@andnorda Får ikke id + class selector til å fungere med purgecss, så kommenterte den ut for nå.

Eksempel:
```css
#breadcrumbs-wrapper.white {
  background-color: #f1f1f1;
}

#breadcrumbs-wrapper.gray {
  background-color: var(--a-bg-subtle);
}

#breadcrumbs-wrapper.transparent {
    background-color: transparent;
}
```
Dette er også noe som jeg lurer på: "Setter bakgrunnsfargen på containeren til brødsmulesti og språkvelger". Jeg klarer ikke å finne noe språkvelger i dagens dekoratør 🤔  Vet du hva det sikter til?