### PR TITLE
Prod ingress

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,66 @@
+name: Build and deploy to nais
+on:
+  workflow_call:
+    inputs:
+      NAIS_VARS:
+        required: true
+        type: string
+      IMAGE_NAME:
+        required: true
+        type: string
+      CLUSTER:
+        required: true
+        type: string
+
+jobs:
+  build_and_deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      image: ghcr.io/${{ github.repository }}:${{ inputs.IMAGE_NAME }}-${{ github.sha }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: '10.0.14'
+      - name: Install dependencies
+        run: bun install --immutable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - name: Build app
+        run: bun run build
+      - name: Run tests
+        run: bun run test
+      - name: upload to CDN
+        uses: navikt/frontend/actions/cdn-upload/v1@main
+        with:
+          cdn-team-name: personbruker
+          source: './packages/server/public'
+          destination: '/decorator-next-${{ inputs.CLUSTER }}'
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: 'ghcr.io'
+          username: '${{ github.actor }}'
+          password: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Build and push Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          tags: '${{ inputs.IMAGE_NAME }}'
+          push: 'true'
+
+      - uses: nais/deploy/actions/deploy@master
+        env:
+          CLUSTER: ${{ inputs.CLUSTER }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          RESOURCE: .nais/config.yaml
+          VAR: image=${{ env.image }},BUILD_ID=${{ github.sha }}
+          VARS: ${{ inputs.NAIS_VARS }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,6 +11,9 @@ on:
       CLUSTER:
         required: true
         type: string
+      CDN_ENVIRONMENT:
+        required: true
+        type: string
 
 jobs:
   build_and_deploy:
@@ -40,7 +43,8 @@ jobs:
         with:
           cdn-team-name: personbruker
           source: './packages/server/public'
-          destination: '/decorator-next-${{ inputs.CLUSTER }}'
+          destination: '/decorator-next'
+          cdn-environment: '${{ inputs.CDN_ENVIRONMENT }}'
 
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v1

--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -14,5 +14,6 @@ jobs:
       NAIS_VARS: .nais/vars/dev.yml
       IMAGE_NAME: decorator-next
       CLUSTER: dev-gcp
+      CDN_ENVIRONMENT: cdn.dev.nav.no
     secrets: inherit
 

--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -4,83 +4,15 @@ on:
   push:
     branches:
       - main
-env:
-  IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+
 jobs:
-  build:
-    name: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: '1.0.14'
-      - name: Define app environmment
-        run: |
-            cat > .env <<EOF
-            ENV=NAV_NO
-            HOST=https://decorator-next.ekstern.dev.nav.no
-            CDN_URL=https://cdn.nav.no/personbruker/decorator-next/public
-            ENONICXP_SERVICES=https://www.intern.dev.nav.no/_/service
-            XP_BASE_URL=https://www.intern.dev.nav.no
-            AUTH_API_URL=https://login.ekstern.dev.nav.no
-            LOGIN_URL=https://login.ekstern.dev.nav.no/oauth2/login
-            LOGOUT_URL=https://login.ekstern.dev.nav.no/oauth2/logout
-            VARSEL_API_URL=https://www.intern.dev.nav.no/tms-varsel-api
-            API_DEKORATOREN_URL=https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
-            API_SESSION_URL=https://login.ekstern.dev.nav.no/oauth2/session
-            PORT=8089
-            MIN_SIDE_URL=https://www.intern.dev.nav.no/minside
-            MIN_SIDE_ARBEIDSGIVER_URL=https://www.intern.dev.nav.no/min-side-arbeidsgiver
-            PERSONOPPLYSNINGER_URL=https://www.intern.dev.nav.no/person/personopplysninger
-            CASETYPE_ID=66D660EF-6F14-44B4-8ADE-A70A127202D0
-            NAV_GROUP_ID=A034081B-6B73-46B7-BE27-23B8E9CE3079
-            OPPORTUNITY_ID=615FF5E7-37B7-4697-A35F-72598B0DC53B
-            SOLUTION_ID=5EB316A1-11E2-460A-B4E3-F82DBD13E21D
-            EOF
-      - name: Install dependencies
-        run: bun install --immutable
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-      - name: Build app
-        run: bun run build
-      - name: Run tests
-        run: bun run test
-      - name: upload to CDN
-        uses: navikt/frontend/actions/cdn-upload/v1@main
-        with:
-          cdn-team-name: personbruker
-          source: './packages/server/public'
-          destination: '/decorator-next'
-
-      - name: Login to GitHub Docker Registry
-        uses: docker/login-action@v1
-        with:
-          registry: 'ghcr.io'
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Build and push Docker
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          tags: '${{ env.IMAGE }}'
-          push: 'true'
-          no-cache: 'true'
-
   deploy:
-    name: Deploy app
-    needs: 'build'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Deploy app
-        uses: 'nais/deploy/actions/deploy@v1'
-        env:
-          'APIKEY': '${{ secrets.NAIS_DEPLOY_APIKEY }}'
-          'CLUSTER': 'dev-gcp'
-          'RESOURCE': '.nais/config-dev.yml'
+    permissions:
+      packages: write
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      NAIS_VARS: .nais/vars/dev.yml
+      IMAGE_NAME: decorator-next
+      CLUSTER: dev-gcp
+    secrets: inherit
+

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -1,0 +1,85 @@
+
+name: Deploy to prod
+on:
+  release:
+    types: [released]
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: '1.0.14'
+      - name: Define app environmment
+        run: |
+            cat > .env <<EOF
+            ENV=NAV_NO
+            HOST=https://decorator-next.ekstern.dev.nav.no
+            CDN_URL=https://cdn.nav.no/personbruker/decorator-next/public
+            ENONICXP_SERVICES=https://www.intern.dev.nav.no/_/service
+            XP_BASE_URL=https://www.intern.dev.nav.no
+            AUTH_API_URL=https://login.ekstern.dev.nav.no
+            LOGIN_URL=https://login.ekstern.dev.nav.no/oauth2/login
+            LOGOUT_URL=https://login.ekstern.dev.nav.no/oauth2/logout
+            VARSEL_API_URL=https://www.intern.dev.nav.no/tms-varsel-api
+            API_DEKORATOREN_URL=https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
+            API_SESSION_URL=https://login.ekstern.dev.nav.no/oauth2/session
+            PORT=8089
+            MIN_SIDE_URL=https://www.intern.dev.nav.no/minside
+            MIN_SIDE_ARBEIDSGIVER_URL=https://www.intern.dev.nav.no/min-side-arbeidsgiver
+            PERSONOPPLYSNINGER_URL=https://www.intern.dev.nav.no/person/personopplysninger
+            CASETYPE_ID=66D660EF-6F14-44B4-8ADE-A70A127202D0
+            NAV_GROUP_ID=A034081B-6B73-46B7-BE27-23B8E9CE3079
+            OPPORTUNITY_ID=615FF5E7-37B7-4697-A35F-72598B0DC53B
+            SOLUTION_ID=5EB316A1-11E2-460A-B4E3-F82DBD13E21D
+            EOF
+      - name: Install dependencies
+        run: bun install --immutable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - name: Build app
+        run: bun run build
+      - name: Run tests
+        run: bun run test
+      - name: upload to CDN
+        uses: navikt/frontend/actions/cdn-upload/v1@main
+        with:
+          cdn-team-name: personbruker
+          source: './packages/server/public'
+          destination: '/decorator-next-prod'
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: 'ghcr.io'
+          username: '${{ github.actor }}'
+          password: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Build and push Docker
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          tags: '${{ env.IMAGE }}'
+          push: 'true'
+
+  deploy:
+    name: Deploy app
+    needs: 'build'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy app
+        uses: 'nais/deploy/actions/deploy@v1'
+        env:
+          'APIKEY': '${{ secrets.NAIS_DEPLOY_APIKEY }}'
+          'CLUSTER': 'prod-gcp'
+          'RESOURCE': '.nais/config-dev.yml'

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -13,4 +13,5 @@ jobs:
       NAIS_VARS: .nais/vars/prod.yaml
       IMAGE_NAME: release-${{ github.ref_name }}
       CLUSTER: prod-gcp
+      CDN_ENVIRONMENT: cdn.nav.no
     secrets: inherit

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -1,85 +1,16 @@
-
 name: Deploy to prod
 on:
   release:
     types: [released]
 
-env:
-  IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 jobs:
-  build:
-    name: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: '1.0.14'
-      - name: Define app environmment
-        run: |
-            cat > .env <<EOF
-            ENV=NAV_NO
-            HOST=https://decorator-next.ekstern.dev.nav.no
-            CDN_URL=https://cdn.nav.no/personbruker/decorator-next/public
-            ENONICXP_SERVICES=https://www.intern.dev.nav.no/_/service
-            XP_BASE_URL=https://www.intern.dev.nav.no
-            AUTH_API_URL=https://login.ekstern.dev.nav.no
-            LOGIN_URL=https://login.ekstern.dev.nav.no/oauth2/login
-            LOGOUT_URL=https://login.ekstern.dev.nav.no/oauth2/logout
-            VARSEL_API_URL=https://www.intern.dev.nav.no/tms-varsel-api
-            API_DEKORATOREN_URL=https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
-            API_SESSION_URL=https://login.ekstern.dev.nav.no/oauth2/session
-            PORT=8089
-            MIN_SIDE_URL=https://www.intern.dev.nav.no/minside
-            MIN_SIDE_ARBEIDSGIVER_URL=https://www.intern.dev.nav.no/min-side-arbeidsgiver
-            PERSONOPPLYSNINGER_URL=https://www.intern.dev.nav.no/person/personopplysninger
-            CASETYPE_ID=66D660EF-6F14-44B4-8ADE-A70A127202D0
-            NAV_GROUP_ID=A034081B-6B73-46B7-BE27-23B8E9CE3079
-            OPPORTUNITY_ID=615FF5E7-37B7-4697-A35F-72598B0DC53B
-            SOLUTION_ID=5EB316A1-11E2-460A-B4E3-F82DBD13E21D
-            EOF
-      - name: Install dependencies
-        run: bun install --immutable
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-      - name: Build app
-        run: bun run build
-      - name: Run tests
-        run: bun run test
-      - name: upload to CDN
-        uses: navikt/frontend/actions/cdn-upload/v1@main
-        with:
-          cdn-team-name: personbruker
-          source: './packages/server/public'
-          destination: '/decorator-next-prod'
-
-      - name: Login to GitHub Docker Registry
-        uses: docker/login-action@v1
-        with:
-          registry: 'ghcr.io'
-          username: '${{ github.actor }}'
-          password: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Build and push Docker
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          tags: '${{ env.IMAGE }}'
-          push: 'true'
-
   deploy:
-    name: Deploy app
-    needs: 'build'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Deploy app
-        uses: 'nais/deploy/actions/deploy@v1'
-        env:
-          'APIKEY': '${{ secrets.NAIS_DEPLOY_APIKEY }}'
-          'CLUSTER': 'prod-gcp'
-          'RESOURCE': '.nais/config-dev.yml'
+    permissions:
+      packages: write
+    if: github.event.release.target_commitish == 'master'
+    uses: ./.github/workflows/build-and-deploy.yml
+    with:
+      NAIS_VARS: .nais/vars/prod.yaml
+      IMAGE_NAME: release-${{ github.ref_name }}
+      CLUSTER: prod-gcp
+    secrets: inherit

--- a/.nais/config.yml
+++ b/.nais/config.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: nais.io/v1alpha1
+kind: Application
+metadata:
+  name: {{appName}}
+  namespace: personbruker
+  labels:
+    team: personbruker
+spec:
+  image: {{image}}
+  port: 8088
+  liveness:
+    path: {{appPath}}/isAlive
+  readiness:
+    path: {{appPath}}/isReady
+  prometheus:
+    enabled: true
+    path: {{appPath}}/metrics
+  ingresses:
+  {{#each ingresses as |url|}}
+    - {{url}}
+  {{/each}}
+  accessPolicy:
+    outbound:
+      external:
+        {{#each outboundHosts as |host|}}
+        - host: {{host}}
+        {{/each}}
+    inbound:
+      rules:
+        - application: "*"
+          namespace: "*"
+  env:
+    - name: BUILD_ID
+      value: {{BUILD_ID}}
+  {{#each env as |var|}}
+    - name: {{var.name}}
+      value: {{var.value}}
+  {{/each}}
+  envFrom:
+    - secret: decorator-next-unleash-api-token
+  replicas:
+  {{#with replicas}}
+    min: {{min}}
+    max: {{max}}
+  {{/with}}
+  resources:
+  {{#with resources}}
+    requests:
+      cpu: {{requests.cpu}}
+      memory: {{requests.memory}}
+    limits:
+      memory: {{limits.memory}}
+  {{/with}}
+

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -8,27 +8,46 @@ outboundHosts:
   - www.intern.dev.nav.no
   - navno-unleash-api.nav.cloud.nais.io
   - tokendings.dev-gcp.nais.io
+
 env:
   - name: ENV
     value: NAV_NO
+  - name: HOST
+    value: https://decorator-next.ekstern.dev.nav.no
+  - name: CDN_URL
+    value: https://cdn.nav.no/personbruker/decorator-next-dev-gcp/public
+  - name: ENONICXP_SERVICES
+    value: https://www.intern.dev.nav.no/_/service
   - name: XP_BASE_URL
-    value: https://www.ekstern.dev.nav.no
-  - name: APP_BASE_URL
-    value: https://dekoratoren.ekstern.dev.nav.no
-  - name: API_XP_SERVICES_URL
-    value: https://portal-admin-dev.oera.no/_/service
-  - name: API_DEKORATOREN_URL
-    value: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
-  - name: MINSIDE_ARBEIDSGIVER_URL
-    value: https://min-side-arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver/
-  - name: MIN_SIDE_URL
-    value: https://www.intern.dev.nav.no/minside/
+    value: https://www.intern.dev.nav.no
+  - name: AUTH_API_URL
+    value: https://login.ekstern.dev.nav.no
   - name: LOGIN_URL
     value: https://login.ekstern.dev.nav.no/oauth2/login
   - name: LOGOUT_URL
     value: https://login.ekstern.dev.nav.no/oauth2/logout
   - name: VARSEL_API_URL
     value: https://www.intern.dev.nav.no/tms-varsel-api
+  - name: API_DEKORATOREN_URL
+    value: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
+  - name: API_SESSION_URL
+    value: https://login.ekstern.dev.nav.no/oauth2/session
+  - name: PORT
+    value: 8089
+  - name: MIN_SIDE_URL
+    value: https://www.intern.dev.nav.no/minside
+  - name: MIN_SIDE_ARBEIDSGIVER_URL
+    value: https://www.intern.dev.nav.no/min-side-arbeidsgiver
+  - name: PERSONOPPLYSNINGER_URL
+    value: https://www.intern.dev.nav.no/person/personopplysninger
+  - name: CASETYPE_ID
+    value: 66D660EF-6F14-44B4-8ADE-A70A127202D0
+  - name: NAV_GROUP_ID
+    value: A034081B-6B73-46B7-BE27-23B8E9CE3079
+  - name: OPPORTUNITY_ID
+    value: 615FF5E7-37B7-4697-A35F-72598B0DC53B
+  - name: SOLUTION_ID
+    value: 5EB316A1-11E2-460A-B4E3-F82DBD13E21D
 replicas:
   min: 1
   max: 2

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -15,7 +15,7 @@ env:
   - name: HOST
     value: https://decorator-next.ekstern.dev.nav.no
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next-dev-gcp/public
+    value: https://cdn.dev.nav.no/personbruker/decorator-next/public
   - name: ENONICXP_SERVICES
     value: https://www.intern.dev.nav.no/_/service
   - name: XP_BASE_URL

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -1,0 +1,40 @@
+appName: decorator-next
+appPath: ''
+port: 8089
+ingresses:
+  - https://decorator-next.ekstern.dev.nav.no
+outboundHosts:
+  - www.nav.no
+  - www.intern.dev.nav.no
+  - navno-unleash-api.nav.cloud.nais.io
+  - tokendings.dev-gcp.nais.io
+env:
+  - name: ENV
+    value: NAV_NO
+  - name: XP_BASE_URL
+    value: https://www.ekstern.dev.nav.no
+  - name: APP_BASE_URL
+    value: https://dekoratoren.ekstern.dev.nav.no
+  - name: API_XP_SERVICES_URL
+    value: https://portal-admin-dev.oera.no/_/service
+  - name: API_DEKORATOREN_URL
+    value: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
+  - name: MINSIDE_ARBEIDSGIVER_URL
+    value: https://min-side-arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver/
+  - name: MIN_SIDE_URL
+    value: https://www.intern.dev.nav.no/minside/
+  - name: LOGIN_URL
+    value: https://login.ekstern.dev.nav.no/oauth2/login
+  - name: LOGOUT_URL
+    value: https://login.ekstern.dev.nav.no/oauth2/logout
+  - name: VARSEL_API_URL
+    value: https://www.intern.dev.nav.no/tms-varsel-api
+replicas:
+  min: 1
+  max: 2
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    memory: 512Mi

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -14,7 +14,7 @@ env:
   - name: HOST
     value: https://www.nav.no/decorator-next
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next-prod/public
+    value: https://cdn.nav.no/personbruker/decorator-next-prod-gcp/public
   - name: ENONICXP_SERVICES
     value:  https://www.nav.no/_/service
   - name: XP_BASE_URL

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -14,7 +14,7 @@ env:
   - name: HOST
     value: https://www.nav.no/decorator-next
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next-prod-gcp/public
+    value: https://cdn.nav.no/personbruker/decorator-next/public
   - name: ENONICXP_SERVICES
     value:  https://www.nav.no/_/service
   - name: XP_BASE_URL

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -1,0 +1,58 @@
+appName: decorator-next
+appPath: ''
+port: 8089
+ingresses:
+  - https://www.nav.no/decorator-next
+outboundHosts:
+  - www.nav.no
+  - www.intern.dev.nav.no
+  - navno-unleash-api.nav.cloud.nais.io
+  - tokendings.dev-gcp.nais.io
+env:
+  - name: ENV
+    value: NAV_NO
+  - name: HOST
+    value: https://www.nav.no/decorator-next
+  - name: CDN_URL
+    value: https://cdn.nav.no/personbruker/decorator-next-prod/public
+  - name: ENONICXP_SERVICES
+    value:  https://www.nav.no/_/service
+  - name: XP_BASE_URL
+    value: https://www.nav.no
+  - name: AUTH_API_URL
+    value: https://login.dev.nav.no
+  - name: LOGIN_URL
+    value: https://login.nav.no/oauth2/login
+  - name: LOGOUT_URL
+    value: https://login.nav.no/oauth2/logout
+  - name: VARSEL_API_URL
+    value: https://www.nav.no/tms-varsel-api
+  - name: API_DEKORATOREN_URL
+    value: https://www.nav.no/person/nav-dekoratoren-api
+  - name: API_SESSION_URL
+    value: https://login.nav.no/oauth2/session
+  - name: PORT
+    value: 8089
+  - name: MIN_SIDE_URL
+    value: https://www.nav.no/minside/
+  - name: MIN_SIDE_ARBEIDSGIVER_URL
+    value: https://www.intern.dev.nav.no/min-side-arbeidsgiver
+  - name: PERSONOPPLYSNINGER_URL
+    value: https://www.nav.no/person/personopplysninger
+  - name: CASETYPE_ID
+    value: 66D660EF-6F14-44B4-8ADE-A70A127202D0
+  - name: NAV_GROUP_ID
+    value: A034081B-6B73-46B7-BE27-23B8E9CE3079
+  - name: OPPORTUNITY_ID
+    value: 615FF5E7-37B7-4697-A35F-72598B0DC53B
+  - name: SOLUTION_ID
+    value: 5EB316A1-11E2-460A-B4E3-F82DBD13E21D
+replicas:
+  min: 1
+  max: 2
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    memory: 512Mi


### PR DESCRIPTION
Forsøk på å standardisere GHA og kunne ha ulike miljøer.

Vesentlige endringer:
- Satt opp build-and-deploy gjennbrukbar workflow
- Bruker [cdn_environment](https://github.com/navikt/frontend/blob/main/actions/cdn-upload/v1/action.yaml) for å ha to ulike CDN miljøer for assets
- Bruker .nais/vars istedenfor å inline environment variabler

Har kopiert over en del fra dagens dekoratør, så funker sikkert ikke first try.