### PR TITLE
Fjerner deploy key etter ny støtte i nais

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -56,7 +56,6 @@ jobs:
       - uses: nais/deploy/actions/deploy@master
         env:
           CLUSTER: ${{ inputs.CLUSTER }}
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           RESOURCE: .nais/config.yml
           VAR: image=${{ steps.docker-push.outputs.image }},BUILD_ID=${{ github.sha }}
           VARS: ${{ inputs.NAIS_VARS }}

--- a/.github/workflows/deploy-unleash-api-token.yml
+++ b/.github/workflows/deploy-unleash-api-token.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/unleash-api-token.dev.yaml
 
@@ -30,6 +29,5 @@ jobs:
         uses: nais/deploy/actions/deploy@v1
         if: github.ref == 'refs/heads/main'
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/unleash-api-token.prod.yaml

--- a/.github/workflows/deploy-unleash-api-token.yml
+++ b/.github/workflows/deploy-unleash-api-token.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Deploy application
-        uses: nais/deploy/actions/deploy@v1
+        uses: nais/deploy/actions/deploy@master
         env:
           CLUSTER: dev-gcp
           RESOURCE: .nais/unleash-api-token.dev.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Deploy application
-        uses: nais/deploy/actions/deploy@v1
+        uses: nais/deploy/actions/deploy@master
         if: github.ref == 'refs/heads/main'
         env:
           CLUSTER: prod-gcp


### PR DESCRIPTION
NAIS støtter autentisering ved deploy basert på navn på repo så det er ikke lenger nødvendig med egen deploy key.