### PR TITLE
Tweaks for sticky header

### DIFF
--- a/packages/client/src/styles/sticky.module.css
+++ b/packages/client/src/styles/sticky.module.css
@@ -11,7 +11,7 @@
 }
 
 .stickyContent {
-    position: fixed;
+    position: absolute;
     width: 100%;
     border-bottom: 1px solid var(--a-border-subtle);
     background-color: var(--a-surface-default);
@@ -19,6 +19,10 @@
     transition-property: transform, visibility;
     transition-duration: 0.15s;
     transition-timing-function: ease-in-out;
+}
+
+.sticky {
+    position: fixed;
 }
 
 .hidden {

--- a/packages/client/src/views/sticky.ts
+++ b/packages/client/src/views/sticky.ts
@@ -1,11 +1,11 @@
 import cls from 'decorator-client/src/styles/sticky.module.css';
 
+const STICKY_OFFSET_PROPERTY = '--decorator-sticky-offset';
+const STICKY_TRIGGER_DELTA_PX = 20;
+const HEADER_HEIGHT_PX = 80;
+
 // @TODO Resizing
 class Sticky extends HTMLElement {
-    // The number of pixels to scroll before showing/hiding the sticky header
-    private readonly delta = 20;
-    private readonly headerHeight = 80;
-
     private stickyContent: HTMLElement;
 
     private prevScrollOffset: number = 0;
@@ -17,15 +17,16 @@ class Sticky extends HTMLElement {
         this.stickyContent = this.querySelector(`.${cls.stickyContent}`)!;
     }
 
-
     private handleScroll = () => {
         const currentScrollOffset = window.scrollY;
         const currentScrollDirection = this.prevScrollOffset > currentScrollOffset ? 'up' : 'down';
 
         this.prevScrollOffset = currentScrollOffset;
 
-        if (currentScrollOffset < this.headerHeight) {
-            this.stickyContent.classList.remove(cls.hidden);
+        if (currentScrollOffset < HEADER_HEIGHT_PX) {
+            if (currentScrollDirection === 'down') {
+                this.dock();
+            }
             return;
         }
 
@@ -35,20 +36,49 @@ class Sticky extends HTMLElement {
             return;
         }
 
-        if (Math.abs(this.offsetAtDirectionChange - currentScrollOffset) < this.delta) {
+        if (Math.abs(this.offsetAtDirectionChange - currentScrollOffset) < STICKY_TRIGGER_DELTA_PX) {
             return;
         }
 
         if (currentScrollDirection === 'down') {
-            this.stickyContent.classList.add(cls.hidden);
+            this.unstick();
         } else {
-            this.stickyContent.classList.remove(cls.hidden);
+            this.stick();
         }
     };
+
+    private dock() {
+        this.stickyContent.classList.remove(cls.hidden);
+        this.stickyContent.classList.remove(cls.sticky);
+        document.documentElement.style.setProperty(STICKY_OFFSET_PROPERTY, '0px');
+    }
+
+    private stick() {
+        this.stickyContent.classList.remove(cls.hidden);
+        this.stickyContent.classList.add(cls.sticky);
+        document.documentElement.style.setProperty(STICKY_OFFSET_PROPERTY, `${HEADER_HEIGHT_PX}px`);
+    }
+
+    private unstick() {
+        this.stickyContent.classList.add(cls.hidden);
+        document.documentElement.style.setProperty(STICKY_OFFSET_PROPERTY, '0px');
+    }
+
+    private init() {
+        const currentScrollOffset = window.scrollY;
+        this.prevScrollOffset = currentScrollOffset;
+
+        if (currentScrollOffset < HEADER_HEIGHT_PX) {
+            this.stick();
+        } else {
+            this.unstick();
+        }
+    }
 
     private connectedCallback() {
         this.stickyContent = this.querySelector(`.${cls.stickyContent}`)!;
         this.prevScrollOffset = window.scrollY;
+        this.init();
 
         window.addEventListener('scroll', this.handleScroll);
     }


### PR DESCRIPTION
- Setter CSS property `--decorator-sticky-offset` tilsvarende gammel dekoratør. Denne benyttes av appene for å tilpasse egne sticky-elementer i forhold til headeren.
- Tweaker scrolling til toppen for en smoothere oppførsel
- Sørger for at sticky-header ikke vises før scrolling har skjedd (f.eks. dersom initiell posisjon er midt på siden).