### PR TITLE
Event-listener for å lukke dropdown-menyer

### DIFF
--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -17,7 +17,7 @@ export type CustomEvents = {
     menuopened: void;
     menuclosed: void;
     clearsearch: void;
-    closemenus: void;
+    closemenus: void; // Currently fired only from other apps
 };
 
 export type MessageEvents =

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -14,6 +14,10 @@ export type CustomEvents = {
     authupdated: {
         auth: Auth;
     };
+    menuopened: void;
+    menuclosed: void;
+    clearsearch: void;
+    closemenus: void;
 };
 
 export type MessageEvents =

--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -17,11 +17,7 @@ class DropdownMenu extends HTMLElement {
         }
 
         this.classList.toggle(cls.dropdownMenuOpen, open);
-        if (!this.button?.getAttribute('aria-expanded')) {
-            this.button?.setAttribute('aria-expanded', 'true');
-        } else {
-            this.button?.removeAttribute('aria-expanded');
-        }
+        this.button?.toggleAttribute('aria-expanded');
         this.#open = open;
         this.dispatchEvent(createEvent(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
     }

--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -17,7 +17,7 @@ class DropdownMenu extends HTMLElement {
         }
 
         this.classList.toggle(cls.dropdownMenuOpen, open);
-        this.button?.toggleAttribute('aria-expanded');
+        this.button?.setAttribute('aria-expanded', JSON.stringify(open));
         this.#open = open;
         this.dispatchEvent(createEvent(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
     }

--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -12,17 +12,23 @@ class DropdownMenu extends HTMLElement {
     };
 
     set open(open: boolean) {
-        if (open !== this.#open) {
-            this.classList.toggle(cls.dropdownMenuOpen, open);
-            if (!this.button?.getAttribute('aria-expanded')) {
-                this.button?.setAttribute('aria-expanded', 'true');
-            } else {
-                this.button?.removeAttribute('aria-expanded');
-            }
-            this.#open = open;
-            this.dispatchEvent(createEvent(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
+        if (open === this.#open) {
+            return;
         }
+
+        this.classList.toggle(cls.dropdownMenuOpen, open);
+        if (!this.button?.getAttribute('aria-expanded')) {
+            this.button?.setAttribute('aria-expanded', 'true');
+        } else {
+            this.button?.removeAttribute('aria-expanded');
+        }
+        this.#open = open;
+        this.dispatchEvent(createEvent(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
     }
+
+    close = () => {
+        this.open = false;
+    };
 
     connectedCallback() {
         this.button = this.querySelector(':scope > button');
@@ -32,10 +38,12 @@ class DropdownMenu extends HTMLElement {
         });
 
         window.addEventListener('click', this.handleWindowClick);
+        window.addEventListener('closemenus', this.close);
     }
 
     disconnectedCallback() {
         window.removeEventListener('click', this.handleWindowClick);
+        window.removeEventListener('closemenus', this.close);
     }
 }
 

--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -28,10 +28,12 @@ class DropdownMenu extends HTMLElement {
 
     connectedCallback() {
         this.button = this.querySelector(':scope > button');
-
-        this.button?.addEventListener('click', () => {
-            this.open = !this.#open;
-        });
+        if (this.button) {
+            this.button.addEventListener('click', () => {
+                this.open = !this.#open;
+            });
+            this.button.setAttribute('aria-expanded', 'false');
+        }
 
         window.addEventListener('click', this.handleWindowClick);
         window.addEventListener('closemenus', this.close);

--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -1,4 +1,5 @@
 import cls from '../styles/dropdown-menu.module.css';
+import { createEvent } from '../events';
 
 class DropdownMenu extends HTMLElement {
     button: HTMLElement | null = null;
@@ -19,7 +20,7 @@ class DropdownMenu extends HTMLElement {
                 this.button?.removeAttribute('aria-expanded');
             }
             this.#open = open;
-            this.dispatchEvent(new Event(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
+            this.dispatchEvent(createEvent(open ? 'menuopened' : 'menuclosed', { bubbles: true }));
         }
     }
 

--- a/packages/client/src/views/search-input.ts
+++ b/packages/client/src/views/search-input.ts
@@ -1,4 +1,5 @@
 import cls from '../styles/search-form.module.css';
+import { createEvent } from '../events';
 
 class SearchInput extends HTMLElement {
     clearButton: HTMLButtonElement | null = null;
@@ -14,7 +15,7 @@ class SearchInput extends HTMLElement {
 
         this.clearButton?.addEventListener('click', () => {
             this.clearButton?.classList.remove(cls.visible);
-            this.dispatchEvent(new Event('clearsearch', { bubbles: true }));
+            this.dispatchEvent(createEvent('clearsearch', { bubbles: true }));
             if (this.input) {
                 this.input.focus();
             }


### PR DESCRIPTION
Kan benyttes av andre apper ved behov for å lukke menyen. I praksis er det kun vår XP-frontend app som trenger dette. Tenker det ryddigste er at denne fyrer av dette eventet ved behov, fremfor dagens prod-løsning der dekoratøren selv alltid lukker menyen ved klikk på lenker.

- Tweaker noen custom-events litt for bedre autocomplete etc
- Fikser aria-expanded attribute på dropdown-menyer for konsistent korrekte verdier