### PR TITLE
Omskrivning/bugfixes for initialisering av analyse-verktøy

### DIFF
--- a/packages/client/src/analytics/amplitude.ts
+++ b/packages/client/src/analytics/amplitude.ts
@@ -5,6 +5,11 @@ import { Auth } from "decorator-shared/auth";
 
 type EventData = Record<string, any>;
 
+const buildPlatformField = () => {
+    const { origin, pathname, hash } = window.location;
+    return `${origin}${pathname}${hash}`;
+};
+
 declare global {
     interface Window {
         dekoratorenAmplitude: typeof logEventFromApp;
@@ -18,12 +23,12 @@ export const initAmplitude = () => {
         vindushoyde: window.innerHeight,
     };
 
-    amplitude.init("default", "", {
+    amplitude.getInstance().init("default", "", {
         apiEndpoint: "amplitude.nav.no/collect-auto",
         saveEvents: false,
         includeUtm: true,
         includeReferrer: true,
-        platform: window.location.toString(),
+        platform: buildPlatformField(),
     });
     amplitude.getInstance().setUserProperties(userProps);
 
@@ -116,7 +121,7 @@ export const logAmplitudeEvent = (
             eventName,
             {
                 ...eventData,
-                platform: window.location.toString(),
+                platform: buildPlatformField(),
                 origin,
                 originVersion: eventData.originVersion || "unknown",
                 viaDekoratoren: true,

--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -1,9 +1,19 @@
-import { analyticsReady } from "../events";
-import { initAmplitude } from "./amplitude";
+import { initAmplitude, logPageView } from "./amplitude";
 import { initTaskAnalytics } from "./task-analytics/ta";
+import { Auth } from "decorator-shared/auth";
 
-export const initAnalytics = () => {
+export const initAnalytics = (auth: Auth) => {
     initAmplitude();
     initTaskAnalytics();
-    dispatchEvent(analyticsReady);
+
+    logPageView(window.__DECORATOR_DATA__.params, auth);
+
+    window.addEventListener("historyPush", () =>
+        // TODO: can this be solved in a more dependable manner?
+        // setTimeout to ensure window.location is updated after the history push
+        setTimeout(
+            () => logPageView(window.__DECORATOR_DATA__.params, auth),
+            250,
+        ),
+    );
 };

--- a/packages/client/src/analytics/task-analytics/ta-matching.ts
+++ b/packages/client/src/analytics/task-analytics/ta-matching.ts
@@ -7,18 +7,18 @@ import {
 } from "./ta-cookies";
 import { Context } from "decorator-shared/params";
 import {
-    TaskAnalyticsSurveyConfig,
+    TaskAnalyticsSurvey,
     TaskAnalyticsUrlRule,
-} from "decorator-shared/types";
+} from "decorator-server/src/task-analytics-config";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
 const norwayTz = "Europe/Oslo";
 
-type Audience = Required<TaskAnalyticsSurveyConfig>["audience"][number];
-type Language = Required<TaskAnalyticsSurveyConfig>["language"][number];
-type Duration = TaskAnalyticsSurveyConfig["duration"];
+type Audience = Required<TaskAnalyticsSurvey>["audience"][number];
+type Language = Required<TaskAnalyticsSurvey>["language"][number];
+type Duration = TaskAnalyticsSurvey["duration"];
 
 const removeTrailingSlash = (str: string) => str.replace(/\/$/, "");
 
@@ -82,7 +82,7 @@ const isMatchingDuration = (duration: Duration) => {
 };
 
 export const taskAnalyticsIsMatchingSurvey = (
-    survey: TaskAnalyticsSurveyConfig,
+    survey: TaskAnalyticsSurvey,
     currentLanguage: Language,
     currentAudience: Audience,
     currentUrl: URL,
@@ -98,7 +98,7 @@ export const taskAnalyticsIsMatchingSurvey = (
 };
 
 export const taskAnalyticsGetMatchingSurveys = (
-    surveys: TaskAnalyticsSurveyConfig[],
+    surveys: TaskAnalyticsSurvey[],
     currentLanguage: Language,
     currentAudience: Context,
     currentUrl: URL,

--- a/packages/client/src/analytics/task-analytics/ta.ts
+++ b/packages/client/src/analytics/task-analytics/ta.ts
@@ -114,7 +114,7 @@ const fetchAndStart = async (state: AppState, currentUrl: URL) => {
         });
 };
 
-export const startTaskAnalyticsSurvey = (
+const startTaskAnalyticsSurvey = (
     state: AppState,
     currentUrl = new URL(window.location.href),
 ) => {

--- a/packages/client/src/analytics/task-analytics/ta.ts
+++ b/packages/client/src/analytics/task-analytics/ta.ts
@@ -9,9 +9,10 @@ import {
     taskAnalyticsIsMatchingSurvey,
 } from "./ta-matching";
 import { Context, Language } from "decorator-shared/params";
-import { AppState, TaskAnalyticsSurveyConfig } from "decorator-shared/types";
+import { AppState } from "decorator-shared/types";
+import { TaskAnalyticsSurvey } from "decorator-server/src/task-analytics-config";
 
-let fetchedSurveys: TaskAnalyticsSurveyConfig[] | null = null;
+let fetchedSurveys: TaskAnalyticsSurvey[] | null = null;
 
 const taFallback = (...args: any[]) => {
     window.TA.q = window.TA.q || [];
@@ -25,7 +26,7 @@ const startSurvey = (surveyId: string) => {
 
 const startSurveyIfMatching = (
     surveyId: string,
-    surveys: TaskAnalyticsSurveyConfig[],
+    surveys: TaskAnalyticsSurvey[],
     currentLanguage: Language,
     currentAudience: Context,
     currentUrl: URL,
@@ -45,7 +46,7 @@ const startSurveyIfMatching = (
 };
 
 const findAndStartSurvey = (
-    surveys: TaskAnalyticsSurveyConfig[],
+    surveys: TaskAnalyticsSurvey[],
     state: AppState,
     currentUrl: URL,
 ) => {
@@ -129,6 +130,8 @@ export const startTaskAnalyticsSurvey = (
 export const initTaskAnalytics = () => {
     window.TA = window.TA || taFallback;
     window.dataLayer = window.dataLayer || [];
+
+    startTaskAnalyticsSurvey(window.__DECORATOR_DATA__);
 
     window.addEventListener("historyPush", (e) =>
         startTaskAnalyticsSurvey(window.__DECORATOR_DATA__, e.detail.url),

--- a/packages/client/src/auth.ts
+++ b/packages/client/src/auth.ts
@@ -18,6 +18,7 @@ const fetchAuthData = async (): Promise<AuthDataResponse> => {
 const updateAuthData = () =>
     fetchAuthData().then((authResponse) => {
         dispatchEvent(createEvent("authupdated", { detail: authResponse }));
+        return authResponse;
     });
 
 const updateAuthOnContextSwitch = (
@@ -28,8 +29,8 @@ const updateAuthOnContextSwitch = (
     }
 };
 
-export const initAuth = () => {
-    updateAuthData().then(() => {
+export const initAuth = () =>
+    updateAuthData().then((authResponse) => {
         window.addEventListener("paramsupdated", updateAuthOnContextSwitch);
+        return authResponse.auth;
     });
-};

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -2,7 +2,6 @@ import { Context, Params } from "decorator-shared/params";
 import { AuthDataResponse } from "decorator-shared/auth";
 
 export type CustomEvents = {
-    "analytics-ready-event": void;
     activecontext: { context: Context };
     paramsupdated: {
         params: Partial<Params>;
@@ -28,18 +27,12 @@ export type MessageEvents =
           payload: Partial<Params>;
       };
 
-export type EventName = keyof CustomEvents;
-
 export function createEvent<TName extends keyof CustomEvents>(
     name: TName,
     options: CustomEventInit<CustomEvents[TName]>,
 ) {
     return new CustomEvent(name, options);
 }
-
-export const analyticsReady = new CustomEvent("analytics-ready-event", {
-    bubbles: true,
-});
 
 type PushStateArgs = Parameters<typeof window.history.pushState>;
 type ReplaceStateArgs = Parameters<typeof window.history.replaceState>;

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -28,12 +28,10 @@ import "./views/sticky";
 import "./views/user-menu";
 import "./views/skip-link";
 import { addFaroMetaData } from "./faro";
-import { analyticsReady, createEvent, initHistoryEvents } from "./events";
+import { createEvent, initHistoryEvents } from "./events";
 import { type ParamKey } from "decorator-shared/params";
 import { param, hasParam, updateDecoratorParams, env } from "./params";
 import { initAnalytics } from "./analytics/analytics";
-import { logPageView } from "./analytics/amplitude";
-import { startTaskAnalyticsSurvey } from "./analytics/task-analytics/ta";
 import { initAuth } from "./auth";
 
 import.meta.glob("./styles/*.css", { eager: true });
@@ -121,32 +119,6 @@ window.addEventListener("activecontext", (event) => {
     });
 });
 
-const init = async () => {
-    initHistoryEvents();
-    initAnalytics();
-    initAuth();
-};
-
-window.addEventListener(analyticsReady.type, () => {
-    startTaskAnalyticsSurvey(window.__DECORATOR_DATA__);
-});
-
-// TODO: this runs too often, should only run once :)
-window.addEventListener("authupdated", (e) => {
-    const { auth } = e.detail;
-
-    logPageView(window.__DECORATOR_DATA__.params, auth);
-
-    window.addEventListener("historyPush", () =>
-        // TODO: can this be solved in a more dependable manner?
-        // setTimeout to ensure window.location is updated after the history push
-        setTimeout(
-            () => logPageView(window.__DECORATOR_DATA__.params, auth),
-            250,
-        ),
-    );
-});
-
 // @TODO: Refactor loaders
 window.addEventListener("load", () => {
     useLoadIfActiveSession({
@@ -154,5 +126,12 @@ window.addEventListener("load", () => {
     });
     addFaroMetaData();
 });
+
+const init = async () => {
+    initHistoryEvents();
+    initAuth().then((auth) => {
+        initAnalytics(auth);
+    });
+};
 
 init();

--- a/packages/client/src/views/main-menu.ts
+++ b/packages/client/src/views/main-menu.ts
@@ -1,16 +1,15 @@
 import { Context } from "decorator-shared/params";
 import { CustomEvents } from "../events";
-import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
+import { ResponseCache } from "decorator-shared/response-cache";
 import { param } from "../params";
 import { endpointUrlWithParams } from "../helpers/urls";
 
 const TEN_MIN_MS = 10 * 60 * 1000;
 
 class MainMenu extends HTMLElement {
-    private readonly responseCache =
-        new StaleWhileRevalidateResponseCache<string>({
-            ttl: TEN_MIN_MS,
-        });
+    private readonly responseCache = new ResponseCache<string>({
+        ttl: TEN_MIN_MS,
+    });
 
     private async fetchMenuContent(context: Context) {
         const url = endpointUrlWithParams("/main-menu", { context });

--- a/packages/server/src/menu/main-menu.ts
+++ b/packages/server/src/menu/main-menu.ts
@@ -1,4 +1,4 @@
-import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
+import { ResponseCache } from "decorator-shared/response-cache";
 import { Context, Language } from "decorator-shared/params";
 import { Link, LinkGroup, MainMenuContextLink } from "decorator-shared/types";
 import { clientEnv, env } from "../env/server";
@@ -13,7 +13,7 @@ const MENU_SERVICE_URL = `${env.ENONICXP_SERVICES}/no.nav.navno/menu`;
 
 const ONE_MINUTE_MS = 60 * 1000;
 
-const menuCache = new StaleWhileRevalidateResponseCache<MainMenu>({
+const menuCache = new ResponseCache<MainMenu>({
     ttl: ONE_MINUTE_MS,
 });
 

--- a/packages/server/src/ops-msgs.ts
+++ b/packages/server/src/ops-msgs.ts
@@ -1,4 +1,4 @@
-import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
+import { ResponseCache } from "decorator-shared/response-cache";
 import { OpsMessage } from "decorator-shared/types";
 import { env } from "./env/server";
 
@@ -6,7 +6,7 @@ const TEN_SECONDS_MS = 10 * 1000;
 
 const DRIFTSMELDINGER_SERVICE_URL = `${env.ENONICXP_SERVICES}/no.nav.navno/driftsmeldinger`;
 
-const opsMsgsCache = new StaleWhileRevalidateResponseCache<OpsMessage[]>({
+const opsMsgsCache = new ResponseCache<OpsMessage[]>({
     ttl: TEN_SECONDS_MS,
 });
 

--- a/packages/server/src/task-analytics-config.ts
+++ b/packages/server/src/task-analytics-config.ts
@@ -3,40 +3,39 @@ import { z } from "zod";
 import { Result, ResultType } from "./result";
 import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
 
-const configSchema = z.array(
-    z.object({
-        id: z.string(),
-        selection: z.optional(z.number()),
-        duration: z.optional(
-            z.object({
-                start: z.optional(z.string()),
-                end: z.optional(z.string()),
-            }),
-        ),
-        urls: z.optional(
-            z.array(
-                z.object({
-                    url: z.string(),
-                    match: z.enum(["exact", "startsWith"]),
-                    exclude: z.optional(z.boolean()),
-                }),
-            ),
-        ),
-        audience: z.optional(z.array(contextSchema)),
-        language: z.optional(z.array(languageSchema)),
-    }),
-);
+export type TaskAnalyticsSurvey = z.infer<typeof taSurveyItemSchema>;
+export type TaskAnalyticsUrlRule = z.infer<typeof taUrlRule>;
 
-type TaskAnalyticsSurveyConfig = z.infer<typeof configSchema>;
+const taUrlRule = z.object({
+    url: z.string(),
+    match: z.enum(["exact", "startsWith"]),
+    exclude: z.optional(z.boolean()),
+});
+
+const taSurveyItemSchema = z.object({
+    id: z.string(),
+    selection: z.optional(z.number()),
+    duration: z.optional(
+        z.object({
+            start: z.optional(z.string()),
+            end: z.optional(z.string()),
+        }),
+    ),
+    urls: z.optional(z.array(taUrlRule)),
+    audience: z.optional(z.array(contextSchema)),
+    language: z.optional(z.array(languageSchema)),
+});
+
+const configSchema = z.array(taSurveyItemSchema);
 
 const TEN_SECONDS_MS = 10 * 1000;
 
-const cache = new StaleWhileRevalidateResponseCache<TaskAnalyticsSurveyConfig>({
+const cache = new StaleWhileRevalidateResponseCache<TaskAnalyticsSurvey[]>({
     ttl: TEN_SECONDS_MS,
 });
 
 export const getTaskAnalyticsConfig = async (): Promise<
-    ResultType<TaskAnalyticsSurveyConfig>
+    ResultType<TaskAnalyticsSurvey[]>
 > =>
     cache
         .get("task-analytics-config", async () => {

--- a/packages/server/src/task-analytics-config.ts
+++ b/packages/server/src/task-analytics-config.ts
@@ -3,16 +3,16 @@ import { z } from "zod";
 import { Result, ResultType } from "./result";
 import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
 
-export type TaskAnalyticsSurvey = z.infer<typeof taSurveyItemSchema>;
-export type TaskAnalyticsUrlRule = z.infer<typeof taUrlRule>;
+export type TaskAnalyticsSurvey = z.infer<typeof taSurveySchema>;
+export type TaskAnalyticsUrlRule = z.infer<typeof taUrlRuleSchema>;
 
-const taUrlRule = z.object({
+const taUrlRuleSchema = z.object({
     url: z.string(),
     match: z.enum(["exact", "startsWith"]),
     exclude: z.optional(z.boolean()),
 });
 
-const taSurveyItemSchema = z.object({
+const taSurveySchema = z.object({
     id: z.string(),
     selection: z.optional(z.number()),
     duration: z.optional(
@@ -21,12 +21,12 @@ const taSurveyItemSchema = z.object({
             end: z.optional(z.string()),
         }),
     ),
-    urls: z.optional(z.array(taUrlRule)),
+    urls: z.optional(z.array(taUrlRuleSchema)),
     audience: z.optional(z.array(contextSchema)),
     language: z.optional(z.array(languageSchema)),
 });
 
-const configSchema = z.array(taSurveyItemSchema);
+const configSchema = z.array(taSurveySchema);
 
 const TEN_SECONDS_MS = 10 * 1000;
 

--- a/packages/server/src/task-analytics-config.ts
+++ b/packages/server/src/task-analytics-config.ts
@@ -1,7 +1,7 @@
 import { contextSchema, languageSchema } from "decorator-shared/params";
 import { z } from "zod";
 import { Result, ResultType } from "./result";
-import { StaleWhileRevalidateResponseCache } from "decorator-shared/response-cache";
+import { ResponseCache } from "decorator-shared/response-cache";
 
 export type TaskAnalyticsSurvey = z.infer<typeof taSurveySchema>;
 export type TaskAnalyticsUrlRule = z.infer<typeof taUrlRuleSchema>;
@@ -30,7 +30,7 @@ const configSchema = z.array(taSurveySchema);
 
 const TEN_SECONDS_MS = 10 * 1000;
 
-const cache = new StaleWhileRevalidateResponseCache<TaskAnalyticsSurvey[]>({
+const cache = new ResponseCache<TaskAnalyticsSurvey[]>({
     ttl: TEN_SECONDS_MS,
 });
 

--- a/packages/shared/response-cache.ts
+++ b/packages/shared/response-cache.ts
@@ -3,9 +3,9 @@ type CacheItem<Type> = {
     expires: number;
 };
 
-// This cache always returns a stale value (if it exists), while revalidating
+// This cache returns a stale value (if it exists), while revalidating
 // the requested value in the background
-export class StaleWhileRevalidateResponseCache<ValueType = unknown> {
+export class ResponseCache<ValueType = unknown> {
     private readonly ttl: number;
     private readonly cache = new Map<string, CacheItem<ValueType>>();
     private readonly pendingPromises = new Map<
@@ -72,6 +72,6 @@ export class StaleWhileRevalidateResponseCache<ValueType = unknown> {
     }
 }
 
-const caches: StaleWhileRevalidateResponseCache[] = [];
+const caches: ResponseCache[] = [];
 
 export const clearCache = () => caches.forEach((cache) => cache.clear());


### PR DESCRIPTION
- Fjerner event listener for authupdate som kan forårsake duplikate pageview logginger, og skriver om init av pageview logging
- Forenkler initialisering av Task Analytics (fjerner unødvendige event listeners)
- Sørger for at platform-feltet til amplitude settes korrekt
- Fikser typer for TA.