### PR TITLE
Skriver om history.push/replace event emitter

### DIFF
--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -9,11 +9,6 @@ export const initAnalytics = (auth: Auth) => {
     logPageView(window.__DECORATOR_DATA__.params, auth);
 
     window.addEventListener("historyPush", () =>
-        // TODO: can this be solved in a more dependable manner?
-        // setTimeout to ensure window.location is updated after the history push
-        setTimeout(
-            () => logPageView(window.__DECORATOR_DATA__.params, auth),
-            250,
-        ),
+        logPageView(window.__DECORATOR_DATA__.params, auth),
     );
 };

--- a/packages/client/src/analytics/task-analytics/ta-matching.ts
+++ b/packages/client/src/analytics/task-analytics/ta-matching.ts
@@ -28,9 +28,9 @@ const isMatchingUrl = (
     match: TaskAnalyticsUrlRule["match"],
 ) => (match === "startsWith" ? currentUrl.startsWith(url) : currentUrl === url);
 
-const isMatchingUrls = (urls: TaskAnalyticsUrlRule[], currentUrl: URL) => {
+const isMatchingUrls = (urls: TaskAnalyticsUrlRule[]) => {
     const currentUrlStr = removeTrailingSlash(
-        `${currentUrl.origin}${currentUrl.pathname}`,
+        `${window.location.origin}${window.location.pathname}`,
     );
 
     let isMatched: boolean | null = null;
@@ -85,12 +85,11 @@ export const taskAnalyticsIsMatchingSurvey = (
     survey: TaskAnalyticsSurvey,
     currentLanguage: Language,
     currentAudience: Audience,
-    currentUrl: URL,
 ) => {
     const { urls, audience, language, duration } = survey;
 
     return (
-        (!urls || isMatchingUrls(urls, currentUrl)) &&
+        (!urls || isMatchingUrls(urls)) &&
         isMatchingAudience(currentAudience, audience) &&
         isMatchingLanguage(currentLanguage, language) &&
         isMatchingDuration(duration)
@@ -101,7 +100,6 @@ export const taskAnalyticsGetMatchingSurveys = (
     surveys: TaskAnalyticsSurvey[],
     currentLanguage: Language,
     currentAudience: Context,
-    currentUrl: URL,
 ) => {
     const { matched: prevMatched = {} } = taskAnalyticsGetState();
 
@@ -120,7 +118,6 @@ export const taskAnalyticsGetMatchingSurveys = (
             survey,
             currentLanguage,
             currentAudience,
-            currentUrl,
         );
         if (!isMatching) {
             return false;

--- a/packages/client/src/analytics/task-analytics/ta.ts
+++ b/packages/client/src/analytics/task-analytics/ta.ts
@@ -115,5 +115,5 @@ export const initTaskAnalytics = () => {
     window.dataLayer = window.dataLayer || [];
 
     startTaskAnalyticsSurvey();
-    window.addEventListener("historyPush", () => startTaskAnalyticsSurvey());
+    window.addEventListener("historyPush", startTaskAnalyticsSurvey);
 };

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -47,9 +47,11 @@ export const initHistoryEvents = () => {
             return;
         }
 
+        // Poll window.location to ensure it has changed before emitting the event
+        // SPA frameworks can sometimes be "slow" with updating this after changing
+        // their history state, so we have this as a workaround
         const currentPathname = window.location.pathname;
         if (currentPathname === prevPathname) {
-            console.log(`Not updated ${currentPathname} ${prevPathname}`);
             setTimeout(() => dispatchHistoryEvent(expiresTs), 50);
             return;
         }

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -48,8 +48,8 @@ export const initHistoryEvents = () => {
         }
 
         const currentPathname = window.location.pathname;
-
         if (currentPathname === prevPathname) {
+            console.log(`Not updated ${currentPathname} ${prevPathname}`);
             setTimeout(() => dispatchHistoryEvent(expiresTs), 50);
             return;
         }

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -50,7 +50,7 @@ export const initHistoryEvents = () => {
         const currentPathname = window.location.pathname;
 
         if (currentPathname === prevPathname) {
-            setInterval(() => dispatchHistoryEvent(expiresTs), 50);
+            setTimeout(() => dispatchHistoryEvent(expiresTs), 50);
             return;
         }
 
@@ -59,7 +59,7 @@ export const initHistoryEvents = () => {
         prevPathname = currentPathname;
     };
 
-    const handleHistoryCall = (url?: URL | string | null) => {
+    const handleHistoryStateChange = (url?: URL | string | null) => {
         if (!url) {
             return;
         }
@@ -74,13 +74,13 @@ export const initHistoryEvents = () => {
 
     window.history.pushState = (...args: PushStateArgs) => {
         const result = pushStateActual(...args);
-        handleHistoryCall(args[2]);
+        handleHistoryStateChange(args[2]);
         return result;
     };
 
     window.history.replaceState = (...args: ReplaceStateArgs) => {
         const result = replaceStateActual(...args);
-        handleHistoryCall(args[2]);
+        handleHistoryStateChange(args[2]);
         return result;
     };
 };

--- a/packages/client/src/views/ops-messages.ts
+++ b/packages/client/src/views/ops-messages.ts
@@ -37,7 +37,7 @@ const removeTrailingChars = (url?: string) =>
 class OpsMessages extends HTMLElement {
     private messages: OpsMessage[] = [];
 
-    private connectedCallback() {
+    connectedCallback() {
         fetch(`${env("APP_URL")}/ops-messages`)
             .then((res) => res.json())
             .then((opsMessages) => {
@@ -45,18 +45,14 @@ class OpsMessages extends HTMLElement {
                 this.render();
             });
 
-        window.addEventListener("historyPush", (e) =>
-            this.render(e.detail.url),
-        );
+        window.addEventListener("historyPush", () => this.render());
         window.addEventListener("popstate", () => this.render());
     }
 
-    private render(url?: URL) {
+    private render() {
         const filteredMessages = this.messages.filter(
             (opsMessage: OpsMessage) => {
-                const currentUrl = removeTrailingChars(
-                    (url ?? window.location).href,
-                );
+                const currentUrl = removeTrailingChars(window.location.href);
                 return (
                     !opsMessage.urlscope ||
                     !currentUrl ||


### PR DESCRIPTION
Skriver om slik at event emitter'en poller window.location til den er oppdatert med ny url, før den sender eventet.

Er ingen direkte "pen" løsning, men tror dette blir ryddigere i sum enn forrige løsning. Det er litt forvirrende, og lett å innføre bugs når URL'en fra event-detail'en og window.location ikke er i sync, og en ikke kan stole på window.location. 😅

Endrer også rekkefølgen på kallene slik at pushSate/replaceState kjøres før event-emitteren. Dette vil ofte være tilstrekkelig til at pollingen ikke kjøres.