### PR TITLE
Fiks av varsler i dekoratør

### DIFF
--- a/packages/client/src/helpers/urls.ts
+++ b/packages/client/src/helpers/urls.ts
@@ -11,8 +11,5 @@ export const endpointUrlWithParams = (
         ...params,
     });
 
-    console.log(`${env("APP_URL")}${endpointUrl}?${formattedParams}`);
-    console.log("endpointurl - " + endpointUrl);
-
     return `${env("APP_URL")}${endpointUrl}?${formattedParams}`;
 };

--- a/packages/client/src/helpers/urls.ts
+++ b/packages/client/src/helpers/urls.ts
@@ -11,5 +11,8 @@ export const endpointUrlWithParams = (
         ...params,
     });
 
+    console.log(`${env("APP_URL")}${endpointUrl}?${formattedParams}`);
+    console.log("endpointurl - " + endpointUrl);
+
     return `${env("APP_URL")}${endpointUrl}?${formattedParams}`;
 };

--- a/packages/client/src/views/notifications.ts
+++ b/packages/client/src/views/notifications.ts
@@ -48,6 +48,7 @@ class LinkNotification extends HTMLElement {
         anchorElement.addEventListener("click", () => {
             fetch(endpointUrlWithParams(`/api/notifications/${id}/archive`), {
                 method: "POST",
+                credentials: "include",
             }).then((res) => {
                 if (!res.ok) {
                     this.handleError();

--- a/packages/client/src/views/notifications.ts
+++ b/packages/client/src/views/notifications.ts
@@ -31,20 +31,38 @@ class ArchivableNotification extends HTMLElement {
 customElements.define("archivable-notification", ArchivableNotification);
 
 class LinkNotification extends HTMLElement {
+    // TODO: hva skal vi vise hvis poste done-event feiler?
+    private handleError() {}
+
     connectedCallback() {
         const anchorElement = this.querySelector("a");
         if (!anchorElement) {
             return;
         }
 
+        const id = this.getAttribute("data-id");
+        if (!id) {
+            return;
+        }
+
         anchorElement.addEventListener("click", () => {
-            logAmplitudeEvent("navigere", {
-                komponent:
-                    this.getAttribute("data-type") === "task"
-                        ? "varsel-oppgave"
-                        : "varsel-beskjed",
-                kategori: "varselbjelle",
-                destinasjon: anchorElement.href,
+            fetch(endpointUrlWithParams(`/api/notifications/${id}/archive`), {
+                method: "POST",
+            }).then((res) => {
+                if (!res.ok) {
+                    this.handleError();
+                    return;
+                }
+
+                this.parentElement?.remove();
+                logAmplitudeEvent("navigere", {
+                    komponent:
+                        this.getAttribute("data-type") === "task"
+                            ? "varsel-oppgave"
+                            : "varsel-beskjed",
+                    kategori: "varselbjelle",
+                    destinasjon: anchorElement.href,
+                });
             });
         });
     }

--- a/packages/client/src/views/notifications.ts
+++ b/packages/client/src/views/notifications.ts
@@ -46,7 +46,18 @@ class LinkNotification extends HTMLElement {
             return;
         }
 
+        const type = this.getAttribute("data-type");
+
         anchorElement.addEventListener("click", () => {
+            if (type === "inbox") {
+                logAmplitudeEvent("navigere", {
+                    komponent: "varsel-innboks",
+                    kategori: "varselbjelle",
+                    destinasjon: anchorElement.href,
+                });
+                return;
+            }
+
             fetch(endpointUrlWithParams(`/api/notifications/${id}/archive`), {
                 method: "POST",
                 credentials: "include",

--- a/packages/client/src/views/notifications.ts
+++ b/packages/client/src/views/notifications.ts
@@ -15,6 +15,7 @@ class ArchivableNotification extends HTMLElement {
         this.querySelector("button")?.addEventListener("click", () =>
             fetch(endpointUrlWithParams(`/api/notifications/${id}/archive`), {
                 method: "POST",
+                credentials: "include",
             }).then((res) => {
                 if (!res.ok) {
                     this.handleError();

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -92,7 +92,7 @@ export const archiveNotification = async ({
             cookie,
             "Content-Type": "application/json",
         },
-        body: JSON.stringify(id),
+        body: JSON.stringify({ eventId: id }),
     });
 
     if (!fetchResult.ok) {

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -82,11 +82,11 @@ export const getNotifications = async ({
             headers: { cookie },
         },
         varslerSchema,
-    ).then((result) => {
-        return result.ok
+    ).then((result) =>
+        result.ok
             ? { ...result, data: varslerToNotifications(result.data) }
-            : result;
-    });
+            : result,
+    );
 };
 
 export const archiveNotification = async ({

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -16,7 +16,6 @@ const varselSchema = z.object({
 const varslerSchema = z.object({
     oppgaver: z.array(varselSchema),
     beskjeder: z.array(varselSchema),
-    innboks: z.array(varselSchema),
 });
 
 type Varsel = z.infer<typeof varselSchema>;

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -5,7 +5,7 @@ import { fetchAndValidateJson } from "./lib/fetch-and-validate";
 
 const varselSchema = z.object({
     eventId: z.string(),
-    type: z.enum(["oppgave", "beskjed"]),
+    type: z.enum(["oppgave", "beskjed", "innboks"]),
     tidspunkt: z.string(),
     isMasked: z.boolean(),
     tekst: z.string().nullable(),
@@ -16,6 +16,7 @@ const varselSchema = z.object({
 const varslerSchema = z.object({
     oppgaver: z.array(varselSchema),
     beskjeder: z.array(varselSchema),
+    innboks: z.array(varselSchema),
 });
 
 type Varsel = z.infer<typeof varselSchema>;
@@ -24,7 +25,7 @@ export type Varsler = z.infer<typeof varslerSchema>;
 
 export type MaskedNotification = {
     id: string;
-    type: "task" | "message";
+    type: NotificationType;
     date: string;
     channels: string[];
     masked: true;
@@ -32,7 +33,7 @@ export type MaskedNotification = {
 
 export type UnmaskedNotification = {
     id: string;
-    type: "task" | "message";
+    type: NotificationType;
     date: string;
     channels: string[];
     masked: false;
@@ -42,12 +43,22 @@ export type UnmaskedNotification = {
 
 export type Notification = MaskedNotification | UnmaskedNotification;
 
+type NotificationType = "message" | "task" | "inbox";
+
+const translateNotificationType = {
+    beskjed: "message",
+    oppgave: "task",
+    innboks: "inbox",
+};
+
 const varslerToNotifications = (varsler: Varsler): Notification[] =>
     [varsler.oppgaver, varsler.beskjeder].flatMap((list) =>
         list.map(
             (varsel: Varsel): Notification => ({
                 id: varsel.eventId,
-                type: varsel.type === "beskjed" ? "message" : "task",
+                type: translateNotificationType[
+                    varsel.type
+                ] as NotificationType,
                 date: varsel.tidspunkt,
                 channels: varsel.eksternVarslingKanaler,
                 ...(varsel.isMasked

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -91,6 +91,7 @@ export const archiveNotification = async ({
         headers: {
             cookie,
             "Content-Type": "application/json",
+            credentials: "include",
         },
         body: JSON.stringify({ eventId: id }),
     });

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -95,6 +95,10 @@ export const archiveNotification = async ({
         body: JSON.stringify({ eventId: id }),
     });
 
+    console.log(fetchResult);
+
+    console.log(`${env.VARSEL_API_URL}/beskjed/inaktiver`);
+
     if (!fetchResult.ok) {
         return Result.Error(await fetchResult.text());
     }

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -83,7 +83,6 @@ export const getNotifications = async ({
         },
         varslerSchema,
     ).then((result) => {
-        console.log(result);
         return result.ok
             ? { ...result, data: varslerToNotifications(result.data) }
             : result;

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -95,10 +95,6 @@ export const archiveNotification = async ({
         body: JSON.stringify({ eventId: id }),
     });
 
-    console.log(fetchResult);
-
-    console.log(`${env.VARSEL_API_URL}/beskjed/inaktiver`);
-
     if (!fetchResult.ok) {
         return Result.Error(await fetchResult.text());
     }

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -73,6 +73,7 @@ export const getNotifications = async ({
         },
         varslerSchema,
     ).then((result) => {
+        console.log(result);
         return result.ok
             ? { ...result, data: varslerToNotifications(result.data) }
             : result;

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -72,11 +72,11 @@ export const getNotifications = async ({
             headers: { cookie },
         },
         varslerSchema,
-    ).then((result) =>
-        result.ok
+    ).then((result) => {
+        return result.ok
             ? { ...result, data: varslerToNotifications(result.data) }
-            : result,
-    );
+            : result;
+    });
 };
 
 export const archiveNotification = async ({

--- a/packages/server/src/notifications.ts
+++ b/packages/server/src/notifications.ts
@@ -91,7 +91,6 @@ export const archiveNotification = async ({
         headers: {
             cookie,
             "Content-Type": "application/json",
-            credentials: "include",
         },
         body: JSON.stringify({ eventId: id }),
     });

--- a/packages/server/src/texts.ts
+++ b/packages/server/src/texts.ts
@@ -27,6 +27,7 @@ const nb = {
     earlier_notifications: "Tidligere varsler",
     message: "Beskjed",
     task: "Oppgave",
+    inbox: "Beskjed",
     masked_message_text:
         "Du har fått en melding, logg inn med høyere sikkerhetsnivå for å se meldingen.",
     masked_task_text:
@@ -118,6 +119,7 @@ const en = {
     earlier_notifications: "Earlier notifications",
     message: "Message",
     task: "Task",
+    inbox: "Message",
     masked_message_text:
         "You have a message, please log in with a higher security level to read the message.",
     masked_task_text:

--- a/packages/server/src/views/notifications/notifications.ts
+++ b/packages/server/src/views/notifications/notifications.ts
@@ -54,13 +54,14 @@ const MaskedNotificationComp = ({
     </div>`;
 
 const NotificationComp = ({
-    notification: { type, date, link, text, channels },
+    notification: { id, type, date, link, text, channels },
 }: {
     notification: UnmaskedNotification;
 }) =>
     html` <link-notification
         class="${cls.notification} ${cls.linkNotification}"
         data-type="${type}"
+        data-id="${id}"
     >
         <div class="${cls.header}">
             <div class="${cls.headerLeft}">

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -56,6 +56,7 @@ export type Texts = ClientTexts & {
     earlier_notifications: string;
     message: string;
     task: string;
+    inbox: string;
     masked_message_text: string;
     masked_task_text: string;
     archive: string;


### PR DESCRIPTION
Fikset posting av done eventer for beskjeder, både ved arkivering av beskjeder og når bruker navigerer til lenken via en beskjed.

Lagt inn funksjonalitet for å håndtere innboks-typen av beskjeder, som tidligere førte til at varslene ikke lot seg laste inn.