### PR TITLE
Forbedrer paramsupdated med full tilstand og changedKeys

### DIFF
--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -4,7 +4,10 @@ import { AuthDataResponse } from "decorator-shared/auth";
 export type CustomEvents = {
     activecontext: { context: Context };
     paramsupdated: {
-        params: Partial<ClientParams>;
+        /** Full current params after the update. */
+        params: ClientParams;
+        /** Keys that changed in this update. Use this to decide whether to react. */
+        changedKeys: ReadonlyArray<keyof ClientParams>;
     };
     authupdated: AuthDataResponse;
     menuopened: void;

--- a/packages/client/src/params.test.ts
+++ b/packages/client/src/params.test.ts
@@ -1,0 +1,97 @@
+import { texts } from "decorator-server/src/texts";
+import { CustomEvents } from "./events";
+import { updateDecoratorParams } from "./params";
+
+describe("updateDecoratorParams", () => {
+    beforeEach(() => {
+        window.__DECORATOR_DATA__ = {
+            params: {
+                chatbot: true,
+                chatbotVisible: false,
+                language: "nb",
+                context: "privatperson",
+                simple: false,
+                simpleHeader: false,
+                simpleFooter: false,
+                redirectToApp: false,
+                level: "Level3",
+                availableLanguages: [],
+                breadcrumbs: [],
+                utilsBackground: "transparent",
+                feedback: false,
+                shareScreen: true,
+                logoutWarning: true,
+                ssrMainMenu: false,
+                redirectOnUserChange: false,
+                analyticsQueryParams: [],
+                analyticsRedactFilter: [],
+            },
+            features: {},
+            env: {} as any,
+            texts: texts.nb,
+        } as any;
+    });
+
+    const captureEvent = (): Promise<CustomEvents["paramsupdated"]> =>
+        new Promise((resolve) => {
+            const handler = (e: Event) => {
+                window.removeEventListener("paramsupdated", handler);
+                resolve(
+                    (e as CustomEvent<CustomEvents["paramsupdated"]>).detail,
+                );
+            };
+            window.addEventListener("paramsupdated", handler);
+        });
+
+    it("dispatches full params in event detail", async () => {
+        const eventPromise = captureEvent();
+        updateDecoratorParams({ language: "en" });
+        const { params } = await eventPromise;
+
+        // All keys should be present (full ClientParams, not partial)
+        expect(params.language).toBe("en");
+        expect(params.chatbot).toBe(true);
+        expect(params.chatbotVisible).toBe(false);
+        expect(params.context).toBe("privatperson");
+    });
+
+    it("dispatches changedKeys containing only the updated keys", async () => {
+        const eventPromise = captureEvent();
+        updateDecoratorParams({ language: "en" });
+        const { changedKeys } = await eventPromise;
+
+        expect(changedKeys).toContain("language");
+        expect(changedKeys).not.toContain("chatbot");
+        expect(changedKeys).not.toContain("chatbotVisible");
+        expect(changedKeys).not.toContain("context");
+    });
+
+    it("batches multiple param changes into one event with all changedKeys", async () => {
+        const eventPromise = captureEvent();
+        updateDecoratorParams({ language: "en", context: "arbeidsgiver" });
+        const { changedKeys, params } = await eventPromise;
+
+        expect(changedKeys).toContain("language");
+        expect(changedKeys).toContain("context");
+        expect(params.language).toBe("en");
+        expect(params.context).toBe("arbeidsgiver");
+    });
+
+    it("does not dispatch event when value is unchanged", () => {
+        const handler = vi.fn();
+        window.addEventListener("paramsupdated", handler);
+        updateDecoratorParams({ language: "nb" }); // "nb" is already the current value
+        window.removeEventListener("paramsupdated", handler);
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("only includes actually changed keys when some values are unchanged", async () => {
+        const eventPromise = captureEvent();
+        updateDecoratorParams({ language: "en", chatbot: true }); // chatbot is already true
+        const { changedKeys } = await eventPromise;
+
+        expect(changedKeys).toContain("language");
+        expect(changedKeys).not.toContain("chatbot");
+    });
+});

--- a/packages/client/src/params.ts
+++ b/packages/client/src/params.ts
@@ -21,6 +21,10 @@ export const env = <TKey extends EnvKey>(envKey: TKey) => {
     return window.__DECORATOR_DATA__.env[envKey];
 };
 
+/**
+ * Updates the decorator params and dispatches a `paramsupdated` event with the
+ * full current params and the list of keys that changed.
+ */
 export const updateDecoratorParams = (params: Partial<ClientParams>) => {
     const updatedParams = { ...params };
 
@@ -45,10 +49,14 @@ export const updateDecoratorParams = (params: Partial<ClientParams>) => {
         Cookies.set(LANGUAGE_COOKIE, language);
     }
 
-    if (Object.keys(updatedParams).length > 0) {
+    const changedKeys = Object.keys(updatedParams) as (keyof ClientParams)[];
+    if (changedKeys.length > 0) {
         window.dispatchEvent(
             createEvent("paramsupdated", {
-                detail: { params: updatedParams },
+                detail: {
+                    params: window.__DECORATOR_DATA__.params,
+                    changedKeys,
+                },
             }),
         );
     }

--- a/packages/client/src/params.ts
+++ b/packages/client/src/params.ts
@@ -39,14 +39,12 @@ export const updateDecoratorParams = (params: Partial<ClientParams>) => {
         ...updatedParams,
     };
 
-    const { context, language } = window.__DECORATOR_DATA__.params;
-
-    if (context) {
-        Cookies.set(CONTEXT_COOKIE, context);
+    if (updatedParams.context !== undefined) {
+        Cookies.set(CONTEXT_COOKIE, updatedParams.context);
     }
 
-    if (language) {
-        Cookies.set(LANGUAGE_COOKIE, language);
+    if (updatedParams.language !== undefined) {
+        Cookies.set(LANGUAGE_COOKIE, updatedParams.language);
     }
 
     const changedKeys = Object.keys(updatedParams) as (keyof ClientParams)[];

--- a/packages/client/src/views/breadcrumbs.ts
+++ b/packages/client/src/views/breadcrumbs.ts
@@ -19,7 +19,7 @@ class Breadcrumbs extends HTMLElement {
     handleParamsUpdated = (
         event: CustomEvent<CustomEvents["paramsupdated"]>,
     ) => {
-        if (event.detail.params.breadcrumbs) {
+        if (event.detail.changedKeys.includes("breadcrumbs")) {
             this.update(event.detail.params.breadcrumbs);
         }
     };

--- a/packages/client/src/views/chatbot/chatbot.test.ts
+++ b/packages/client/src/views/chatbot/chatbot.test.ts
@@ -71,6 +71,24 @@ describe("chatbot", () => {
         expect(child.classList).toContain(cls.visible);
     });
 
+    it("stays visible when unrelated params are updated", async () => {
+        const el = await fixture("<d-chatbot></d-chatbot>");
+        const child = el.childNodes[0] as HTMLElement;
+        expect(child.classList).toContain(cls.visible);
+
+        updateDecoratorParams({ language: "en" });
+        expect(child.classList).toContain(cls.visible);
+    });
+
+    it("hides when chatbotVisible changes to false", async () => {
+        const el = await fixture("<d-chatbot></d-chatbot>");
+        const child = el.childNodes[0] as HTMLElement;
+        expect(child.classList).toContain(cls.visible);
+
+        updateDecoratorParams({ chatbotVisible: false });
+        expect(child.classList).not.toContain(cls.visible);
+    });
+
     it("doesnt mount when feature is not toggled", async () => {
         window.__DECORATOR_DATA__.features["dekoratoren.chatbotscript"] = false;
         const el = await fixture("<d-chatbot></d-chatbot>");

--- a/packages/client/src/views/chatbot/chatbot.ts
+++ b/packages/client/src/views/chatbot/chatbot.ts
@@ -54,7 +54,10 @@ class Chatbot extends HTMLElement {
             !chatbot
         ) {
             this.innerHTML = "";
-        } else if (!this.contains(this.button)) {
+            return;
+        }
+
+        if (!this.contains(this.button)) {
             this.appendChild(this.button);
         }
 

--- a/packages/client/src/views/chatbot/chatbot.ts
+++ b/packages/client/src/views/chatbot/chatbot.ts
@@ -1,6 +1,7 @@
 import type { ClientParams } from "decorator-shared/params";
 import { cdnUrl } from "../../helpers/urls";
 import { defineCustomElement } from "../custom-elements";
+import { CustomEvents } from "../../events";
 import i18n from "../i18n";
 import { hasActiveConversation, initBoost, loadScript } from "./boost";
 import cls from "./chatbot.module.css";
@@ -43,16 +44,17 @@ class Chatbot extends HTMLElement {
         window.removeEventListener("paramsupdated", this.paramsUpdatedListener);
     }
 
-    private paramsUpdatedListener = (event: CustomEvent) =>
-        this.update(event.detail.params);
+    private paramsUpdatedListener = (
+        event: CustomEvent<CustomEvents["paramsupdated"]>,
+    ) => this.update(event.detail.params);
 
-    private update = ({ chatbot, chatbotVisible }: Partial<ClientParams>) => {
+    private update = ({ chatbot, chatbotVisible }: ClientParams) => {
         if (
             !window.__DECORATOR_DATA__.features["dekoratoren.chatbotscript"] ||
-            chatbot === false
+            !chatbot
         ) {
             this.innerHTML = "";
-        } else if (chatbot) {
+        } else if (!this.contains(this.button)) {
             this.appendChild(this.button);
         }
 

--- a/packages/client/src/views/context-links.ts
+++ b/packages/client/src/views/context-links.ts
@@ -1,16 +1,19 @@
 import { analyticsClickListener } from "../analytics/analytics";
 import { AnalyticsKategori } from "../analytics/types";
+import { CustomEvents } from "../events";
 import headerClasses from "../styles/header.module.css";
 import { defineCustomElement } from "./custom-elements";
 
 class ContextLinks extends HTMLElement {
-    handleParamsUpdated = (event: CustomEvent) => {
-        if (event.detail.params.context) {
+    handleParamsUpdated = (
+        event: CustomEvent<CustomEvents["paramsupdated"]>,
+    ) => {
+        if (event.detail.changedKeys.includes("context")) {
+            const { context } = event.detail.params;
             this.querySelectorAll("a").forEach((anchor) => {
                 anchor.classList.toggle(
                     headerClasses.lenkeActive,
-                    anchor.getAttribute("data-context") ===
-                        event.detail.params.context,
+                    anchor.getAttribute("data-context") === context,
                 );
             });
         }

--- a/packages/client/src/views/decorator-utils.ts
+++ b/packages/client/src/views/decorator-utils.ts
@@ -29,9 +29,16 @@ class DecoratorUtils extends HTMLElement {
     handleParamsUpdated = (
         event: CustomEvent<CustomEvents["paramsupdated"]>,
     ) => {
-        const { availableLanguages, breadcrumbs, utilsBackground } =
-            event.detail.params;
-        if (availableLanguages || breadcrumbs || utilsBackground) {
+        const relevantKeys = [
+            "availableLanguages",
+            "breadcrumbs",
+            "utilsBackground",
+        ] as const;
+        if (
+            event.detail.changedKeys.some((k) =>
+                relevantKeys.includes(k as (typeof relevantKeys)[number]),
+            )
+        ) {
             this.update();
         }
     };

--- a/packages/client/src/views/footer.ts
+++ b/packages/client/src/views/footer.ts
@@ -21,10 +21,16 @@ class Footer extends HTMLElement {
                     .filter((key) => payload[key] !== undefined)
                     .map((key) => [key, payload[key]]),
             ) as Partial<ClientParams>;
+            const updateKeys = Object.keys(updates) as (keyof ClientParams)[];
+            if (updateKeys.length === 0) return;
             const validated = paramsSchema.partial().safeParse(updates);
-            if (validated.success && Object.keys(validated.data).length > 0) {
-                updateDecoratorParams(validated.data);
-            } else if (!validated.success) {
+            if (validated.success) {
+                updateDecoratorParams(
+                    Object.fromEntries(
+                        updateKeys.map((key) => [key, validated.data[key]]),
+                    ) as Partial<ClientParams>,
+                );
+            } else {
                 logger.warn("Invalid params from postMessage", {
                     error: validated.error,
                 });

--- a/packages/client/src/views/footer.ts
+++ b/packages/client/src/views/footer.ts
@@ -1,5 +1,7 @@
-import type { ClientParams } from "decorator-shared/params";
+import { paramsSchema, type ClientParams } from "decorator-shared/params";
+import { logger } from "decorator-shared/logger";
 import { updateDecoratorParams } from "../params";
+import { CustomEvents } from "../events";
 import { analyticsClickListener } from "../analytics/analytics";
 import { endpointUrlWithParams } from "../helpers/urls";
 import { defineCustomElement } from "./custom-elements";
@@ -14,14 +16,19 @@ class Footer extends HTMLElement {
     private readonly handleMessage = (e: MessageEvent) => {
         const { event, payload } = e.data;
         if (event == "params") {
-            paramsUpdatesToHandle.forEach((key) => {
-                if (payload[key] !== undefined) {
-                    // TODO: validation
-                    updateDecoratorParams({
-                        [key]: payload[key],
-                    });
-                }
-            });
+            const updates = Object.fromEntries(
+                paramsUpdatesToHandle
+                    .filter((key) => payload[key] !== undefined)
+                    .map((key) => [key, payload[key]]),
+            ) as Partial<ClientParams>;
+            const validated = paramsSchema.partial().safeParse(updates);
+            if (validated.success && Object.keys(validated.data).length > 0) {
+                updateDecoratorParams(validated.data);
+            } else if (!validated.success) {
+                logger.warn("Invalid params from postMessage", {
+                    error: validated.error,
+                });
+            }
         }
     };
 
@@ -31,19 +38,16 @@ class Footer extends HTMLElement {
             .then((footer) => (this.innerHTML = footer));
     };
 
-    private readonly handleParamsUpdated = (e: CustomEvent) => {
-        const { context, language, feedback, simple, simpleFooter } =
-            e.detail.params;
-        const isFeedbackChange = feedback !== undefined;
-        const isSimpleChange = simple !== undefined;
-        const isSimpleFooterChange = simpleFooter !== undefined;
-
+    private readonly handleParamsUpdated = (
+        e: CustomEvent<CustomEvents["paramsupdated"]>,
+    ) => {
+        const { changedKeys } = e.detail;
         if (
-            context ||
-            language ||
-            isFeedbackChange ||
-            isSimpleChange ||
-            isSimpleFooterChange
+            changedKeys.includes("context") ||
+            changedKeys.includes("language") ||
+            changedKeys.includes("feedback") ||
+            changedKeys.includes("simple") ||
+            changedKeys.includes("simpleFooter")
         ) {
             this.refreshFooter();
         }

--- a/packages/client/src/views/header.ts
+++ b/packages/client/src/views/header.ts
@@ -1,5 +1,6 @@
 import { endpointUrlWithParams } from "../helpers/urls";
-import { type ClientParams } from "decorator-shared/params";
+import { type ClientParams, paramsSchema } from "decorator-shared/params";
+import { logger } from "decorator-shared/logger";
 import { env, param, updateDecoratorParams } from "../params";
 import { defineCustomElement } from "./custom-elements";
 import { refreshAuthData } from "../helpers/auth";
@@ -50,17 +51,24 @@ class Header extends HTMLElement {
                 event,
                 payload: { pageType, pageTheme, pageTitle, breadcrumbs },
             } = e.data;
-            if (event === "params" && (pageType || pageTheme || pageTitle)) {
-                updateDecoratorParams({
-                    pageTheme,
-                    pageType,
-                    pageTitle,
-                });
-            }
-            if (event === "params" && breadcrumbs) {
-                updateDecoratorParams({
-                    breadcrumbs,
-                });
+            if (event === "params") {
+                const updates: Partial<ClientParams> = {
+                    ...(pageType && { pageType }),
+                    ...(pageTheme && { pageTheme }),
+                    ...(pageTitle && { pageTitle }),
+                    ...(breadcrumbs && { breadcrumbs }),
+                };
+                const validated = paramsSchema.partial().safeParse(updates);
+                if (
+                    validated.success &&
+                    Object.keys(validated.data).length > 0
+                ) {
+                    updateDecoratorParams(validated.data);
+                } else if (!validated.success) {
+                    logger.warn("Invalid params from NKS postMessage", {
+                        error: validated.error,
+                    });
+                }
             }
         }
 
@@ -76,14 +84,19 @@ class Header extends HTMLElement {
         }
 
         if (event == "params") {
-            paramsUpdatesToHandle.forEach((key) => {
-                if (payload[key] !== undefined) {
-                    // TODO: validation
-                    updateDecoratorParams({
-                        [key]: payload[key],
-                    });
-                }
-            });
+            const updates = Object.fromEntries(
+                paramsUpdatesToHandle
+                    .filter((key) => payload[key] !== undefined)
+                    .map((key) => [key, payload[key]]),
+            ) as Partial<ClientParams>;
+            const validated = paramsSchema.partial().safeParse(updates);
+            if (validated.success && Object.keys(validated.data).length > 0) {
+                updateDecoratorParams(validated.data);
+            } else if (!validated.success) {
+                logger.warn("Invalid params from postMessage", {
+                    error: validated.error,
+                });
+            }
         }
     };
 
@@ -102,15 +115,19 @@ class Header extends HTMLElement {
     private readonly handleParamsUpdated = (
         e: CustomEvent<CustomEvents["paramsupdated"]>,
     ) => {
-        const { context, language, simple, simpleHeader } = e.detail.params;
-        const isSimpleChange = simple !== undefined;
-        const isSimpleHeaderChange = simpleHeader !== undefined;
+        const { changedKeys } = e.detail;
+        const isSimpleChange = changedKeys.includes("simple");
+        const isSimpleHeaderChange = changedKeys.includes("simpleHeader");
 
-        if (language || isSimpleChange || isSimpleHeaderChange) {
+        if (
+            changedKeys.includes("language") ||
+            isSimpleChange ||
+            isSimpleHeaderChange
+        ) {
             this.refreshHeader();
             return;
         }
-        if (context) {
+        if (changedKeys.includes("context")) {
             refreshAuthData();
         }
     };

--- a/packages/client/src/views/header.ts
+++ b/packages/client/src/views/header.ts
@@ -58,13 +58,18 @@ class Header extends HTMLElement {
                     ...(pageTitle && { pageTitle }),
                     ...(breadcrumbs && { breadcrumbs }),
                 };
+                const updateKeys = Object.keys(
+                    updates,
+                ) as (keyof ClientParams)[];
+                if (updateKeys.length === 0) return;
                 const validated = paramsSchema.partial().safeParse(updates);
-                if (
-                    validated.success &&
-                    Object.keys(validated.data).length > 0
-                ) {
-                    updateDecoratorParams(validated.data);
-                } else if (!validated.success) {
+                if (validated.success) {
+                    updateDecoratorParams(
+                        Object.fromEntries(
+                            updateKeys.map((key) => [key, validated.data[key]]),
+                        ) as Partial<ClientParams>,
+                    );
+                } else {
                     logger.warn("Invalid params from NKS postMessage", {
                         error: validated.error,
                     });
@@ -89,10 +94,16 @@ class Header extends HTMLElement {
                     .filter((key) => payload[key] !== undefined)
                     .map((key) => [key, payload[key]]),
             ) as Partial<ClientParams>;
+            const updateKeys = Object.keys(updates) as (keyof ClientParams)[];
+            if (updateKeys.length === 0) return;
             const validated = paramsSchema.partial().safeParse(updates);
-            if (validated.success && Object.keys(validated.data).length > 0) {
-                updateDecoratorParams(validated.data);
-            } else if (!validated.success) {
+            if (validated.success) {
+                updateDecoratorParams(
+                    Object.fromEntries(
+                        updateKeys.map((key) => [key, validated.data[key]]),
+                    ) as Partial<ClientParams>,
+                );
+            } else {
                 logger.warn("Invalid params from postMessage", {
                     error: validated.error,
                 });

--- a/packages/client/src/views/language-selector.ts
+++ b/packages/client/src/views/language-selector.ts
@@ -173,11 +173,12 @@ export class LanguageSelector extends HTMLElement {
     handleParamsUpdated = (
         event: CustomEvent<CustomEvents["paramsupdated"]>,
     ) => {
-        if (event.detail.params.language) {
-            this.language = event.detail.params.language;
+        const { changedKeys, params } = event.detail;
+        if (changedKeys.includes("language")) {
+            this.language = params.language;
         }
-        if (event.detail.params.availableLanguages) {
-            this.availableLanguages = event.detail.params.availableLanguages;
+        if (changedKeys.includes("availableLanguages")) {
+            this.availableLanguages = params.availableLanguages;
         }
     };
 

--- a/packages/client/src/views/logout-warning/logout-warning.ts
+++ b/packages/client/src/views/logout-warning/logout-warning.ts
@@ -6,6 +6,7 @@ import {
 import { addSecondsFromNow } from "../../helpers/time";
 import { param } from "../../params";
 import { defineCustomElement } from "../custom-elements";
+import { CustomEvents } from "../../events";
 import { SessionDialog } from "./session-dialog";
 import { TokenDialog } from "./token-dialog";
 
@@ -46,8 +47,13 @@ class LogoutWarning extends HTMLElement {
         };
     };
 
-    private handleParamsUpdated = (event: CustomEvent) => {
-        if (event.detail.params.logoutWarning) {
+    private handleParamsUpdated = (
+        event: CustomEvent<CustomEvents["paramsupdated"]>,
+    ) => {
+        if (
+            event.detail.changedKeys.includes("logoutWarning") &&
+            event.detail.params.logoutWarning
+        ) {
             this.init();
         }
     };

--- a/packages/client/src/views/main-menu.ts
+++ b/packages/client/src/views/main-menu.ts
@@ -5,6 +5,7 @@ import { param } from "../params";
 import { defineCustomElement } from "./custom-elements";
 import { analyticsClickListener } from "../analytics/analytics";
 import { logger } from "decorator-shared/logger";
+import { CustomEvents } from "../events";
 
 const TEN_MIN_MS = 10 * 60 * 1000;
 
@@ -39,8 +40,10 @@ class MainMenu extends HTMLElement {
             });
     };
 
-    handleParamsUpdated = (event: CustomEvent) => {
-        if (event.detail.params.context) {
+    handleParamsUpdated = (
+        event: CustomEvent<CustomEvents["paramsupdated"]>,
+    ) => {
+        if (event.detail.changedKeys.includes("context")) {
             this.updateMenuContent(event.detail.params.context);
         }
     };


### PR DESCRIPTION
Endrer paramsupdated-hendelsen fra å sende kun delta (Partial<ClientParams>) til å sende fullstendig tilstand og en eksplisitt changedKeys-liste. Dette fikser at komponenter feilaktig kunne tolke mangelen på en nøkkel som at verdien var false/undefined.

Fikser:
 - Chatbot-knappen som forsvant etter navigasjon (Frida-bug fra PR #877) – chatbotVisible er nå alltid tilgjengelig i 
hendelsen
 - logout-warning reagerte ikke på logoutWarning: true → false

Andre forbedringer:
 - postMessage-parametre valideres nå via Zod i header og footer
 - Flere updateDecoratorParams-kall fra samme postMessage slås nå sammen til én hendelse
 - Ny testfil params.test.ts + regresjonstester for chatbot