### PR TITLE
Endrer mocknavn til syntetisk navn for tydelighet

### DIFF
--- a/packages/server/src/mocks.ts
+++ b/packages/server/src/mocks.ts
@@ -138,7 +138,7 @@ export const setupMocks = () =>
                 authLevel
                     ? {
                           authenticated: true,
-                          name: "Charlie Jensen",
+                          name: "Ambisiøs Utsikt",
                           securityLevel: authLevel,
                           userId: "12345612345",
                       }

--- a/packages/server/src/views/header/user-menu.stories.ts
+++ b/packages/server/src/views/header/user-menu.stories.ts
@@ -13,7 +13,7 @@ type Story = StoryObj<UserMenuProps>;
 
 export const LowAuthLevel: Story = {
     args: {
-        name: "Charlie Jensen",
+        name: "Ambisiøs Utsikt",
         notifications: [
             {
                 id: "a",
@@ -28,7 +28,7 @@ export const LowAuthLevel: Story = {
 
 export const HighAuthLevel: Story = {
     args: {
-        name: "Charlie Jensen",
+        name: "Ambisiøs Utsikt",
         level: "Level4",
         notifications: [
             {

--- a/tests/next-pages-router.spec.ts
+++ b/tests/next-pages-router.spec.ts
@@ -115,9 +115,9 @@ testNextPagesRouter(
             .click();
 
         await expect(
-            page.getByRole("button", { name: "Charlie Jensen" }),
+            page.getByRole("button", { name: "Ambisiøs Utsikt" }),
         ).toBeVisible();
-        await page.getByRole("button", { name: "Charlie Jensen" }).click();
+        await page.getByRole("button", { name: "Ambisiøs Utsikt" }).click();
         await expect(page.getByText("Du har ingen nye varsler")).toBeVisible();
     },
 );


### PR DESCRIPTION
Vi bør ikke bruke ekte navn i mock-sammenheng - mest av prinsipp enn at det er så farlig akkurat her. Kom med andre ønsker, men foreslår at vi bygger ut med feks "Ambisiøs Utsikt". Eventuelt ord som er lengre slik at vi får stresstestet UI'et.