### PR TITLE
Analytics fikser

### DIFF
--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -22,6 +22,7 @@ export const mockAnalytics = () => {
     return Promise.resolve();
 };
 
+const analyticsController = new AbortController();
 export const initAnalytics = (auth: Auth) => {
     initMockAmplitude(); // Some teams are calling window.dekoratorenAmplitude directly
     initUmami();
@@ -30,15 +31,15 @@ export const initAnalytics = (auth: Auth) => {
     window.dekoratorenAnalytics = logAnalyticsEventFromApp;
     logPageView(auth);
 
-    // Pass the callback as a function reference
-    window.addEventListener("historyPush", logPageViewCallback(auth));
+    window.addEventListener("historyPush", logPageViewCallback(auth), {
+        signal: analyticsController.signal,
+    });
 };
 
 export const stopAnalytics = (auth: Auth) => {
     stopUmami();
 
-    // Pass the same function reference
-    window.removeEventListener("historyPush", logPageViewCallback(auth));
+    analyticsController.abort();
 };
 
 const buildFilteredQueryString = (): string => {

--- a/packages/client/src/analytics/skyra.ts
+++ b/packages/client/src/analytics/skyra.ts
@@ -11,7 +11,6 @@ export const initSkyra = () => {
 };
 
 export const stopSkyra = () => {
-    console.log("stopSkyra called");
     if (typeof window.skyra?.controller?.stop === "function") {
         // Disable surveys by Skyra
         window.skyra.setConsent(false);

--- a/packages/client/src/analytics/skyra.ts
+++ b/packages/client/src/analytics/skyra.ts
@@ -11,19 +11,20 @@ export const initSkyra = () => {
 };
 
 export const stopSkyra = () => {
+    console.log("stopSkyra called");
     if (typeof window.skyra?.controller?.stop === "function") {
         // Disable surveys by Skyra
         window.skyra.setConsent(false);
+    }
+
+    if (window.SKYRA_CONFIG) {
+        delete window.SKYRA_CONFIG;
     }
 
     // Remove Skyra script from DOM
     const skyraScript = document.querySelector(
         'script[src*="skyra-survey.js"]',
     );
-
-    if (window.SKYRA_CONFIG) {
-        delete window.SKYRA_CONFIG;
-    }
 
     if (skyraScript) {
         skyraScript.remove();
@@ -34,7 +35,9 @@ export const stopSkyra = () => {
         delete window.skyra;
     }
 
+    // Not possible to delete skyraSurvey
+    // as it's not a 'configurable' window property
     if (typeof window.skyraSurvey === "object") {
-        delete window.skyraSurvey;
+        window.skyraSurvey = null;
     }
 };


### PR DESCRIPTION
- fix: unload umami fra history event når bruker endrer samtykke
- fix: bruk null istedenfor delete for skyraSurvey
  - delete would silently fail in 'sloppy mode', but crash in strict mode 