### PR TITLE
chore: legg til 'guards' for å sikre at vi ikke bruke ustøttede syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,77 @@ Husky kjører linting når du committer endringene dine. Du kan også kjøre
 
 Testing kjøres med `pnpm run test` og kjører testene for pakkene `/client` og `/server`.
 
+### Nettleserstøtte
+
+Dekoratøren lastes inn på tvers av hele nav.no, så vi kan ikke anta at brukerne har en oppdatert
+nettleser. Nedre grense for nettleserstøtte er definert **ett sted**, i `browserslist`-nøkkelen i
+`package.json` i rotmappen:
+
+```json
+"browserslist": [
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
+    "chrome >= 100",
+    "edge >= 100",
+    "firefox >= 100",
+    "not dead"
+]
+```
+
+Alt annet utledes fra denne verdien. Endrer du den, må du kjøre `pnpm run generate:compat` (se
+under) og committe resultatet.
+
+#### Hvordan grensen håndheves
+
+Ingen enkelt mekanisme fanger opp alt, så vi bruker fire lag:
+
+| Lag                                   | Fanger opp                                                 | Feiler i         |
+| ------------------------------------- | ---------------------------------------------------------- | ---------------- |
+| Vite `build.target`                   | **Syntaks** – esbuild kompilerer ned, eller stopper bygget | `pnpm run build` |
+| TypeScript `lib: ["ES2022"]`          | **ES-innebygde** – `Object.groupBy`, `Array#toSorted` osv. | `tsc --noEmit`   |
+| `eslint-plugin-compat`                | **Web-API-er** – instansmetoder, properties, konstruktører | `pnpm run lint`  |
+| `no-restricted-properties` (generert) | **Statiske Web-API-er** – `AbortSignal.timeout` osv.       | `pnpm run lint`  |
+
+Hvorfor de to siste er separate lag: datasettet til `eslint-plugin-compat`
+(`ast-metadata-inferer`) inneholder ikke statiske medlemmer i det hele tatt. MDN navngir dem med
+suffikset `_static` (`AbortSignal.timeout_static`), og disse hoppes over. Uten det fjerde laget
+ville `AbortSignal.timeout()` – som krever Safari 16 – gått rett gjennom bygget og feilet i
+produksjon hos brukere på Safari 15.4.
+
+Lista i `eslint-compat-restrictions.generated.mjs` genereres direkte fra
+`@mdn/browser-compat-data`:
+
+```bash
+pnpm run generate:compat
+```
+
+Fila er committet med vilje. Det holder lintingen rask, og gjør at endringer i nettlesergrensen blir
+synlige som en diff av hvilke API-er som ble tillatt eller forbudt.
+
+#### Når du trenger et nyere API
+
+Ikke hev grensen for å få lint til å bli grønn. Velg én av disse:
+
+1. **Skriv det om.** Som regel finnes det et ekvivalent eldre API. `AbortSignal.timeout(ms)` kan for
+   eksempel erstattes med `AbortController` + `setTimeout` – se `packages/client/src/helpers/auth.ts`.
+2. **Polyfill det**, og registrer unntaket slik at det blir synlig i review:
+    - for `compat/compat`: legg API-et inn i `settings.polyfills` i `eslint.config.mjs`
+    - for `no-restricted-properties`: bruk en `eslint-disable-next-line`-kommentar på stedet, med en
+      forklaring på hvor polyfillen kommer fra
+
+#### Kjente hull
+
+- **Instansmetoder** som er nyere enn grensen, men som mangler i datasettet til
+  `eslint-plugin-compat` (f.eks. `element.checkVisibility()`), fanges ikke opp. `lib.dom.d.ts` i
+  TypeScript har ingen versjonering, så typesjekken ser dem heller ikke.
+- **`as any`-casting** omgår alle lagene.
+- **CSS** har foreløpig ingen egen håndhevelse. Merk at `build.cssTarget` arver `build.target`, så
+  esbuild kompilerer nå ned CSS-nesting og lignende til nettlesergrensen. Det er ingen erstatning
+  for stylelint eller lightningcss, men det dekker de vanligste fallgruvene.
+- Det innlinjede skriptet i `packages/server/src/views/scripts.ts` sendes til nettleseren som ren
+  tekst og transpileres ikke. Skriver du kode der, må du selv passe på at den holder seg innenfor
+  nettlesergrensen.
+
 ### Deploy til dev
 
 Hvis du ønsker å teste branchen din, kan du deploye den via workflow-triggeren i GitHub Actions

--- a/eslint-compat-restrictions.generated.mjs
+++ b/eslint-compat-restrictions.generated.mjs
@@ -1,0 +1,785 @@
+/**
+ * GENERATED FILE -- DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: pnpm run generate:compat
+ * Source: scripts/generate-compat-restrictions.mjs
+ *
+ * Static Web API members that our supported browser floor does not implement.
+ * These are invisible to eslint-plugin-compat, whose dataset omits static
+ * members. See the script header for the full explanation.
+ *
+ * Browser floor at generation time: chrome 100, edge 100, firefox 100, safari 15.4, safari_ios 15.4
+ * @mdn/browser-compat-data: 6.1.5
+ */
+
+/** @type {Array<{ object: string, property: string, message: string }>} */
+export const compatRestrictedProperties = [
+    {
+        object: "AbortSignal",
+        property: "any",
+        message:
+            "AbortSignal.any is above our browser floor (needs: chrome 116, edge 116, firefox 124, safari_ios 17.4, safari 17.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "AbortSignal",
+        property: "timeout",
+        message:
+            "AbortSignal.timeout is above our browser floor (needs: chrome 124, edge 124, safari_ios 16, safari 16). See CONTRIBUTING.md.",
+    },
+    {
+        object: "AudioDecoder",
+        property: "isConfigSupported",
+        message:
+            "AudioDecoder.isConfigSupported is above our browser floor (needs: firefox 130, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "AudioEncoder",
+        property: "isConfigSupported",
+        message:
+            "AudioEncoder.isConfigSupported is above our browser floor (needs: firefox 130, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "BarcodeDetector",
+        property: "getSupportedFormats",
+        message:
+            "BarcodeDetector.getSupportedFormats is above our browser floor (needs: firefox, safari_ios 17, safari 17). See CONTRIBUTING.md.",
+    },
+    {
+        object: "BluetoothUUID",
+        property: "canonicalUUID",
+        message:
+            "BluetoothUUID.canonicalUUID is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "BluetoothUUID",
+        property: "getCharacteristic",
+        message:
+            "BluetoothUUID.getCharacteristic is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "BluetoothUUID",
+        property: "getDescriptor",
+        message:
+            "BluetoothUUID.getDescriptor is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "BluetoothUUID",
+        property: "getService",
+        message:
+            "BluetoothUUID.getService is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "ClipboardItem",
+        property: "supports",
+        message:
+            "ClipboardItem.supports is above our browser floor (needs: chrome 121, edge 121, firefox 127, safari_ios 18.4, safari 18.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "console",
+        property: "exception",
+        message:
+            "console.exception is above our browser floor (needs: chrome, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Credential",
+        property: "isConditionalMediationAvailable",
+        message:
+            "Credential.isConditionalMediationAvailable is above our browser floor (needs: chrome, edge, firefox, safari_ios 16, safari 16). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CropTarget",
+        property: "fromElement",
+        message:
+            "CropTarget.fromElement is above our browser floor (needs: chrome 104, edge 104, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cap",
+        message:
+            "CSS.cap is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "ch",
+        message:
+            "CSS.ch is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cm",
+        message:
+            "CSS.cm is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqb",
+        message:
+            "CSS.cqb is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqh",
+        message:
+            "CSS.cqh is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqi",
+        message:
+            "CSS.cqi is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqmax",
+        message:
+            "CSS.cqmax is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqmin",
+        message:
+            "CSS.cqmin is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "cqw",
+        message:
+            "CSS.cqw is above our browser floor (needs: chrome 105, edge 105, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "deg",
+        message:
+            "CSS.deg is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dpcm",
+        message:
+            "CSS.dpcm is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dpi",
+        message:
+            "CSS.dpi is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dppx",
+        message:
+            "CSS.dppx is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvb",
+        message:
+            "CSS.dvb is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvh",
+        message:
+            "CSS.dvh is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvi",
+        message:
+            "CSS.dvi is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvmax",
+        message:
+            "CSS.dvmax is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvmin",
+        message:
+            "CSS.dvmin is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "dvw",
+        message:
+            "CSS.dvw is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "em",
+        message:
+            "CSS.em is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "ex",
+        message:
+            "CSS.ex is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "fr",
+        message:
+            "CSS.fr is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "grad",
+        message:
+            "CSS.grad is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "highlights",
+        message:
+            "CSS.highlights is above our browser floor (needs: chrome 105, edge 105, firefox 140, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "Hz",
+        message:
+            "CSS.Hz is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "ic",
+        message:
+            "CSS.ic is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "in",
+        message:
+            "CSS.in is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "kHz",
+        message:
+            "CSS.kHz is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lh",
+        message:
+            "CSS.lh is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvb",
+        message:
+            "CSS.lvb is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvh",
+        message:
+            "CSS.lvh is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvi",
+        message:
+            "CSS.lvi is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvmax",
+        message:
+            "CSS.lvmax is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvmin",
+        message:
+            "CSS.lvmin is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "lvw",
+        message:
+            "CSS.lvw is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "mm",
+        message:
+            "CSS.mm is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "ms",
+        message:
+            "CSS.ms is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "number",
+        message:
+            "CSS.number is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "paintWorklet",
+        message:
+            "CSS.paintWorklet is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "pc",
+        message:
+            "CSS.pc is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "percent",
+        message:
+            "CSS.percent is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "pt",
+        message:
+            "CSS.pt is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "px",
+        message:
+            "CSS.px is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "Q",
+        message:
+            "CSS.Q is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rad",
+        message:
+            "CSS.rad is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rcap",
+        message:
+            "CSS.rcap is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rch",
+        message:
+            "CSS.rch is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "registerProperty",
+        message:
+            "CSS.registerProperty is above our browser floor (needs: firefox 128, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rem",
+        message:
+            "CSS.rem is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rex",
+        message:
+            "CSS.rex is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "ric",
+        message:
+            "CSS.ric is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 17.2, safari 17.2). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "rlh",
+        message:
+            "CSS.rlh is above our browser floor (needs: chrome 118, edge 118, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "s",
+        message:
+            "CSS.s is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svb",
+        message:
+            "CSS.svb is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svh",
+        message:
+            "CSS.svh is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svi",
+        message:
+            "CSS.svi is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svmax",
+        message:
+            "CSS.svmax is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svmin",
+        message:
+            "CSS.svmin is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "svw",
+        message:
+            "CSS.svw is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "turn",
+        message:
+            "CSS.turn is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vb",
+        message:
+            "CSS.vb is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vh",
+        message:
+            "CSS.vh is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vi",
+        message:
+            "CSS.vi is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vmax",
+        message:
+            "CSS.vmax is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vmin",
+        message:
+            "CSS.vmin is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSS",
+        property: "vw",
+        message:
+            "CSS.vw is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSSNumericValue",
+        property: "parse",
+        message:
+            "CSSNumericValue.parse is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSSStyleValue",
+        property: "parse",
+        message:
+            "CSSStyleValue.parse is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "CSSStyleValue",
+        property: "parseAll",
+        message:
+            "CSSStyleValue.parseAll is above our browser floor (needs: firefox, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "DeviceMotionEvent",
+        property: "requestPermission",
+        message:
+            "DeviceMotionEvent.requestPermission is above our browser floor (needs: chrome, edge, firefox, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "DeviceOrientationEvent",
+        property: "requestPermission",
+        message:
+            "DeviceOrientationEvent.requestPermission is above our browser floor (needs: chrome, edge, firefox, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "DigitalCredential",
+        property: "userAgentAllowsProtocol",
+        message:
+            "DigitalCredential.userAgentAllowsProtocol is above our browser floor (needs: chrome, edge, firefox, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Document",
+        property: "parseHTML",
+        message:
+            "Document.parseHTML is above our browser floor (needs: chrome, edge, firefox 139, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Document",
+        property: "parseHTMLUnsafe",
+        message:
+            "Document.parseHTMLUnsafe is above our browser floor (needs: chrome 124, edge 124, firefox 128, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "HTMLScriptElement",
+        property: "supports",
+        message:
+            "HTMLScriptElement.supports is above our browser floor (needs: safari_ios 16, safari 16). See CONTRIBUTING.md.",
+    },
+    {
+        object: "IdentityCredential",
+        property: "disconnect",
+        message:
+            "IdentityCredential.disconnect is above our browser floor (needs: chrome 122, edge 122, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "IdentityProvider",
+        property: "close",
+        message:
+            "IdentityProvider.close is above our browser floor (needs: chrome 120, edge 120, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "IdentityProvider",
+        property: "getUserInfo",
+        message:
+            "IdentityProvider.getUserInfo is above our browser floor (needs: chrome 116, edge 116, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "IdentityProvider",
+        property: "resolve",
+        message:
+            "IdentityProvider.resolve is above our browser floor (needs: chrome 132, edge 132, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "IdleDetector",
+        property: "requestPermission",
+        message:
+            "IdleDetector.requestPermission is above our browser floor (needs: edge 114, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "ImageDecoder",
+        property: "isTypeSupported",
+        message:
+            "ImageDecoder.isTypeSupported is above our browser floor (needs: firefox 133, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "LanguageDetector",
+        property: "availability",
+        message:
+            "LanguageDetector.availability is above our browser floor (needs: chrome 138, edge, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "LanguageDetector",
+        property: "create",
+        message:
+            "LanguageDetector.create is above our browser floor (needs: chrome 138, edge, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "MediaSource",
+        property: "canConstructInDedicatedWorker",
+        message:
+            "MediaSource.canConstructInDedicatedWorker is above our browser floor (needs: chrome 108, edge 108, firefox, safari_ios 18, safari 18). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Notification",
+        property: "maxActions",
+        message:
+            "Notification.maxActions is above our browser floor (needs: safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Notification",
+        property: "permission",
+        message:
+            "Notification.permission is above our browser floor (needs: safari_ios 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Notification",
+        property: "requestPermission",
+        message:
+            "Notification.requestPermission is above our browser floor (needs: safari_ios 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Observable",
+        property: "from",
+        message:
+            "Observable.from is above our browser floor (needs: chrome 135, edge 135, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PaymentRequest",
+        property: "securePaymentConfirmationAvailability",
+        message:
+            "PaymentRequest.securePaymentConfirmationAvailability is above our browser floor (needs: chrome 139, edge 139, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PressureObserver",
+        property: "knownSources",
+        message:
+            "PressureObserver.knownSources is above our browser floor (needs: chrome 125, edge 125, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "getClientCapabilities",
+        message:
+            "PublicKeyCredential.getClientCapabilities is above our browser floor (needs: chrome 133, edge 133, firefox 135, safari_ios 17.4, safari 17.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "isConditionalMediationAvailable",
+        message:
+            "PublicKeyCredential.isConditionalMediationAvailable is above our browser floor (needs: chrome 108, edge 108, firefox 119, safari_ios 16, safari 16). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "parseCreationOptionsFromJSON",
+        message:
+            "PublicKeyCredential.parseCreationOptionsFromJSON is above our browser floor (needs: chrome 129, edge 129, firefox 119, safari_ios 18.4, safari 18.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "parseRequestOptionsFromJSON",
+        message:
+            "PublicKeyCredential.parseRequestOptionsFromJSON is above our browser floor (needs: chrome 129, edge 129, firefox 119, safari_ios 18.4, safari 18.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "signalAllAcceptedCredentials",
+        message:
+            "PublicKeyCredential.signalAllAcceptedCredentials is above our browser floor (needs: chrome 132, edge 132, firefox, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "signalCurrentUserDetails",
+        message:
+            "PublicKeyCredential.signalCurrentUserDetails is above our browser floor (needs: chrome 132, edge 132, firefox, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PublicKeyCredential",
+        property: "signalUnknownCredential",
+        message:
+            "PublicKeyCredential.signalUnknownCredential is above our browser floor (needs: chrome 132, edge 132, firefox, safari_ios 26, safari 26). See CONTRIBUTING.md.",
+    },
+    {
+        object: "PushManager",
+        property: "supportedContentEncodings",
+        message:
+            "PushManager.supportedContentEncodings is above our browser floor (needs: firefox 134, safari_ios 16.4, safari 16). See CONTRIBUTING.md.",
+    },
+    {
+        object: "ReadableStream",
+        property: "from",
+        message:
+            "ReadableStream.from is above our browser floor (needs: chrome, edge, firefox 117, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Response",
+        property: "json",
+        message:
+            "Response.json is above our browser floor (needs: chrome 105, edge 105, firefox 115, safari_ios 17, safari 17). See CONTRIBUTING.md.",
+    },
+    {
+        object: "RestrictionTarget",
+        property: "fromElement",
+        message:
+            "RestrictionTarget.fromElement is above our browser floor (needs: chrome 132, edge 132, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "RTCRtpReceiver",
+        property: "getCapabilities",
+        message:
+            "RTCRtpReceiver.getCapabilities is above our browser floor (needs: firefox 113). See CONTRIBUTING.md.",
+    },
+    {
+        object: "RTCRtpSender",
+        property: "getCapabilities",
+        message:
+            "RTCRtpSender.getCapabilities is above our browser floor (needs: firefox 113). See CONTRIBUTING.md.",
+    },
+    {
+        object: "SpeechRecognition",
+        property: "available",
+        message:
+            "SpeechRecognition.available is above our browser floor (needs: chrome 139, edge 139, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "SpeechRecognition",
+        property: "install",
+        message:
+            "SpeechRecognition.install is above our browser floor (needs: chrome 139, edge 139, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Summarizer",
+        property: "availability",
+        message:
+            "Summarizer.availability is above our browser floor (needs: chrome 138, edge 138, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Summarizer",
+        property: "create",
+        message:
+            "Summarizer.create is above our browser floor (needs: chrome 138, edge 138, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "TaskSignal",
+        property: "any",
+        message:
+            "TaskSignal.any is above our browser floor (needs: chrome 116, edge 116, firefox 142, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Translator",
+        property: "availability",
+        message:
+            "Translator.availability is above our browser floor (needs: chrome 138, edge, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "Translator",
+        property: "create",
+        message:
+            "Translator.create is above our browser floor (needs: chrome 138, edge, firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+    {
+        object: "URL",
+        property: "canParse",
+        message:
+            "URL.canParse is above our browser floor (needs: chrome 120, edge 120, firefox 115, safari_ios 17, safari 17). See CONTRIBUTING.md.",
+    },
+    {
+        object: "URL",
+        property: "parse",
+        message:
+            "URL.parse is above our browser floor (needs: chrome 126, edge 126, firefox 126, safari_ios 18, safari 18). See CONTRIBUTING.md.",
+    },
+    {
+        object: "VideoDecoder",
+        property: "isConfigSupported",
+        message:
+            "VideoDecoder.isConfigSupported is above our browser floor (needs: firefox 130, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "VideoEncoder",
+        property: "isConfigSupported",
+        message:
+            "VideoEncoder.isConfigSupported is above our browser floor (needs: firefox 130, safari_ios 16.4, safari 16.4). See CONTRIBUTING.md.",
+    },
+    {
+        object: "XRWebGLLayer",
+        property: "getNativeFramebufferScaleFactor",
+        message:
+            "XRWebGLLayer.getNativeFramebufferScaleFactor is above our browser floor (needs: firefox, safari_ios, safari). See CONTRIBUTING.md.",
+    },
+];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,29 +3,111 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
+import browserCompat from "eslint-plugin-compat";
+import globals from "globals";
+import { compatRestrictedProperties } from "./eslint-compat-restrictions.generated.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
     baseDirectory: __dirname,
     recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+    allConfig: js.configs.all,
 });
 
-export default [{
-    ignores: ["**/*.js", "**/*.cjs"],
-}, {
-    files: ["**/*.mjs"],
-    languageOptions: {
-        globals: { process: "readonly" },
+export default [
+    {
+        ignores: ["**/*.js", "**/*.cjs"],
     },
-}, ...compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"), {
-    plugins: {
-        "@typescript-eslint": typescriptEslint,
+    {
+        // All .mjs files in this repo are Node-executed tooling (eslint config,
+        // build scripts, next.config). Give them the Node global scope.
+        files: ["**/*.mjs"],
+        languageOptions: {
+            globals: { ...globals.nodeBuiltin, process: "readonly" },
+        },
     },
+    ...compat.extends(
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+    ),
+    {
+        plugins: {
+            "@typescript-eslint": typescriptEslint,
+        },
 
-    rules: {
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-unused-vars": "warn",
+        rules: {
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-unused-vars": "warn",
+        },
     },
-}];
+    {
+        /**
+         * Browser compatibility guard.
+         *
+         * Our supported browser floor is defined by the "browserslist" key in the
+         * root package.json. That single value drives three layers:
+         *
+         *   1. The Vite build target (packages/client/vite.config.ts) guards
+         *      SYNTAX. esbuild downlevels what it can and fails the build on what
+         *      it cannot.
+         *   2. The TypeScript `lib` setting guards ES BUILT-INS. With
+         *      lib: ["ES2022", ...], calls like Object.groupBy or Array#toSorted
+         *      are already type errors.
+         *   3. This config guards WEB APIs, which neither of the above can see.
+         *      `AbortSignal.timeout()` is just a method call: the bundler emits it
+         *      untouched and lib.dom.d.ts is unversioned, so only a compat-data
+         *      aware lint rule can catch it.
+         *
+         * Layer 3 is itself two rules, because one is not enough:
+         *
+         *   - compat/compat covers instance methods, properties and constructors.
+         *     Its dataset (ast-metadata-inferer) omits STATIC members entirely, so
+         *     it does not catch AbortSignal.timeout, URL.canParse, and similar.
+         *   - no-restricted-properties fills exactly that hole, from a list
+         *     generated straight out of @mdn/browser-compat-data. See
+         *     scripts/generate-compat-restrictions.mjs.
+         *
+         * We spread the plugin's own flat/recommended config because it supplies
+         * the browser globals the rule needs to resolve identifiers. Without those
+         * globals compat/compat silently reports nothing.
+         *
+         * Scoped to the packages whose code actually executes in the browser.
+         * decorator-server is deliberately excluded: it targets node24 and would
+         * report false positives for everything.
+         *
+         * To use an API above the floor, polyfill it and record the exemption:
+         * add it to settings.polyfills (for compat/compat) and/or disable
+         * no-restricted-properties at the call site with a comment explaining
+         * where the polyfill comes from. See CONTRIBUTING.md.
+         */
+        ...browserCompat.configs["flat/recommended"],
+        files: [
+            "packages/client/**/*.ts",
+            "packages/shared/**/*.ts",
+            "packages/icons/**/*.ts",
+        ],
+        ignores: [
+            "**/*.test.ts",
+            "**/*.spec.ts",
+            "**/*.stories.ts",
+            "**/test/**",
+            "**/tests/**",
+            "**/*.config.ts",
+        ],
+        settings: {
+            // Also check ES built-ins (Array.prototype.at, ...), not just Web APIs.
+            lintAllEsApis: true,
+            // Web APIs we knowingly ship above the browser floor because they are
+            // polyfilled or otherwise guaranteed to be present at runtime.
+            polyfills: [],
+        },
+        rules: {
+            ...browserCompat.configs["flat/recommended"].rules,
+            "no-restricted-properties": [
+                "error",
+                ...compatRestrictedProperties,
+            ],
+        },
+    },
+];

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "build": "pnpm --filter decorator-icons run build && pnpm --filter decorator-client run build && pnpm --filter decorator-server run build && pnpm run copy-assets",
         "copy-assets": "mkdir -p packages/server/public && copyfiles -u 3 packages/client/dist/assets/**/* packages/server/public/",
         "prepare": "husky",
+        "generate:compat": "node scripts/generate-compat-restrictions.mjs",
         "benchmarking": "./benchmarking/run",
         "playwright": "pnpm exec playwright test"
     },
@@ -37,6 +38,15 @@
     "license": "ISC",
     "workspaces": [
         "packages/*"
+    ],
+    "browserslistComment": "Supported browser floor for all browser-shipped code. Single source of truth: consumed by the client Vite build target (syntax lowering / build failure) and by eslint-plugin-compat (Web + ES API availability). See CONTRIBUTING.md.",
+    "browserslist": [
+        "safari >= 15.4",
+        "ios_saf >= 15.4",
+        "chrome >= 100",
+        "edge >= 100",
+        "firefox >= 100",
+        "not dead"
     ],
     "dependencies": {
         "@types/umami": "2.10.1",
@@ -50,6 +60,7 @@
         "@axe-core/playwright": "4.12.1",
         "@eslint/eslintrc": "3.3.6",
         "@eslint/js": "9.39.5",
+        "@mdn/browser-compat-data": "6.1.5",
         "@playwright/test": "1.62.1",
         "@storybook/addon-docs": "10.5.5",
         "@storybook/html": "10.5.5",
@@ -57,10 +68,14 @@
         "@types/node": "catalog:",
         "@typescript-eslint/eslint-plugin": "8.65.0",
         "@typescript-eslint/parser": "8.65.0",
+        "browserslist": "4.28.8",
+        "browserslist-to-esbuild": "2.1.1",
         "concurrently": "9.2.4",
         "copyfiles": "2.4.1",
         "esbuild-minify-templates": "catalog:",
         "eslint": "catalog:",
+        "eslint-plugin-compat": "7.0.2",
+        "globals": "15.15.0",
         "http-server": "14.1.1",
         "husky": "9.1.7",
         "lint-staged": "16.4.0",

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -65,15 +65,19 @@ const OneMinuteTimeout = 60000;
 const fetchAuthData = async (): Promise<AuthDataResponse> => {
     const url = endpointUrlWithParams("/auth");
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), OneMinuteTimeout);
+
     return fetch(url, {
-        signal: AbortSignal.timeout(OneMinuteTimeout),
+        signal: controller.signal,
         credentials: "include",
     })
         .then((res) => res.json() as Promise<AuthDataResponse>)
-        .catch((error) => {
+        .catch((error): AuthDataResponse => {
             logger.error(`Failed to fetch auth data.`, { error });
             return { auth: { authenticated: false } };
-        });
+        })
+        .finally(() => clearTimeout(timeoutId));
 };
 
 export const refreshAuthData = () =>

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,9 +1,23 @@
 import minifyLiterals from "rollup-plugin-minify-html-literals-v3";
 import { defineConfig } from "vite";
 import { fileURLToPath } from "node:url";
+import browserslistToEsbuild from "browserslist-to-esbuild";
 import { cssModulesScopedNameOption } from "../shared/css-modules-config";
 
 const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Derived from the "browserslist" key in the repo root package.json, which is
+ * the single source of truth for our supported browser floor.
+ *
+ * This makes esbuild downlevel syntax that the floor cannot parse, and fail the
+ * build outright on syntax it cannot downlevel.
+ *
+ * NOTE: this only guards *syntax*. Runtime APIs (AbortSignal.timeout,
+ * Object.groupBy, structuredClone, ...) are invisible to the bundler and are
+ * guarded separately by eslint-plugin-compat. See CONTRIBUTING.md.
+ */
+const browserTargets = browserslistToEsbuild();
 
 const mainConfig = defineConfig({
     resolve: {
@@ -17,7 +31,7 @@ const mainConfig = defineConfig({
     logLevel: "info",
     build: {
         minify: true,
-        target: "ES2022",
+        target: browserTargets,
         manifest: true,
         sourcemap: true,
         // Prevent inlining any asset imports, always import as url
@@ -40,6 +54,7 @@ const csrConfig = defineConfig({
         // Don't clear the output, we want to keep the main bundle
         emptyOutDir: false,
         minify: true,
+        target: browserTargets,
         manifest: ".vite/csr.manifest.json",
         rollupOptions: {
             input: ["src/csr.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
             "@eslint/js":
                 specifier: 9.39.5
                 version: 9.39.5
+            "@mdn/browser-compat-data":
+                specifier: 6.1.5
+                version: 6.1.5
             "@playwright/test":
                 specifier: 1.62.1
                 version: 1.62.1
@@ -77,6 +80,12 @@ importers:
             "@typescript-eslint/parser":
                 specifier: 8.65.0
                 version: 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+            browserslist:
+                specifier: 4.28.8
+                version: 4.28.8
+            browserslist-to-esbuild:
+                specifier: 2.1.1
+                version: 2.1.1(browserslist@4.28.8)
             concurrently:
                 specifier: 9.2.4
                 version: 9.2.4
@@ -89,6 +98,12 @@ importers:
             eslint:
                 specifier: "catalog:"
                 version: 9.39.5
+            eslint-plugin-compat:
+                specifier: 7.0.2
+                version: 7.0.2(eslint@9.39.5)
+            globals:
+                specifier: 15.15.0
+                version: 15.15.0
             http-server:
                 specifier: 14.1.1
                 version: 14.1.1
@@ -1303,6 +1318,18 @@ packages:
         resolution:
             {
                 integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==,
+            }
+
+    "@mdn/browser-compat-data@5.7.6":
+        resolution:
+            {
+                integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==,
+            }
+
+    "@mdn/browser-compat-data@6.1.5":
+        resolution:
+            {
+                integrity: sha512-PzdZZzRhcXvKB0begee28n5lvwAcinGKYuLZOVxHAZm+n7y01ddEGfdS1ZXRuVcV+ndG6mSEAE8vgudom5UjYg==,
             }
 
     "@mdx-js/react@3.1.1":
@@ -3486,6 +3513,12 @@ packages:
             }
         engines: { node: ">=12" }
 
+    ast-metadata-inferer@0.8.1:
+        resolution:
+            {
+                integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==,
+            }
+
     ast-types-flow@0.0.8:
         resolution:
             {
@@ -3568,6 +3601,14 @@ packages:
         engines: { node: ">=6.0.0" }
         hasBin: true
 
+    baseline-browser-mapping@2.11.14:
+        resolution:
+            {
+                integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==,
+            }
+        engines: { node: ">=6.0.0" }
+        hasBin: true
+
     basic-auth@2.0.1:
         resolution:
             {
@@ -3613,10 +3654,28 @@ packages:
             }
         engines: { node: ">=8" }
 
+    browserslist-to-esbuild@2.1.1:
+        resolution:
+            {
+                integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==,
+            }
+        engines: { node: ">=18" }
+        hasBin: true
+        peerDependencies:
+            browserslist: "*"
+
     browserslist@4.28.2:
         resolution:
             {
                 integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
+            }
+        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+        hasBin: true
+
+    browserslist@4.28.8:
+        resolution:
+            {
+                integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==,
             }
         engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
         hasBin: true
@@ -3687,6 +3746,12 @@ packages:
         resolution:
             {
                 integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==,
+            }
+
+    caniuse-lite@1.0.30001809:
+        resolution:
+            {
+                integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==,
             }
 
     chai-a11y-axe@1.5.0:
@@ -4314,6 +4379,12 @@ packages:
                 integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==,
             }
 
+    electron-to-chromium@1.5.406:
+        resolution:
+            {
+                integrity: sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==,
+            }
+
     emoji-regex@10.6.0:
         resolution:
             {
@@ -4536,6 +4607,15 @@ packages:
                 optional: true
             eslint-import-resolver-webpack:
                 optional: true
+
+    eslint-plugin-compat@7.0.2:
+        resolution:
+            {
+                integrity: sha512-gN8hF+4NzMsHUbr4m/TYZK0FtW3DcV4g8rXpTsY2EV5xiRD8jsilUlB9lNSkGGX0veDCxMhKSWbSd+faJByQDA==,
+            }
+        engines: { node: ">=22.x" }
+        peerDependencies:
+            eslint: ^9.0.0 || ^10.0.0
 
     eslint-plugin-import@2.32.0:
         resolution:
@@ -4982,6 +5062,13 @@ packages:
         resolution:
             {
                 integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+            }
+        engines: { node: ">=18" }
+
+    globals@15.15.0:
+        resolution:
+            {
+                integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==,
             }
         engines: { node: ">=18" }
 
@@ -5961,6 +6048,12 @@ packages:
                 integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
             }
 
+    lodash.memoize@4.1.2:
+        resolution:
+            {
+                integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==,
+            }
+
     lodash.merge@4.6.2:
         resolution:
             {
@@ -6085,6 +6178,13 @@ packages:
                 integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
             }
         engines: { node: ">= 0.6" }
+
+    meow@13.2.0:
+        resolution:
+            {
+                integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+            }
+        engines: { node: ">=18" }
 
     merge-stream@2.0.0:
         resolution:
@@ -6375,6 +6475,13 @@ packages:
         resolution:
             {
                 integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==,
+            }
+        engines: { node: ">=18" }
+
+    node-releases@2.0.53:
+        resolution:
+            {
+                integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==,
             }
         engines: { node: ">=18" }
 
@@ -8235,6 +8342,15 @@ packages:
         peerDependencies:
             browserslist: ">= 4.21.0"
 
+    update-browserslist-db@1.3.1:
+        resolution:
+            {
+                integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==,
+            }
+        hasBin: true
+        peerDependencies:
+            browserslist: ">= 4.21.0"
+
     upper-case@1.1.3:
         resolution:
             {
@@ -9217,6 +9333,10 @@ snapshots:
     "@lit/reactive-element@2.1.2":
         dependencies:
             "@lit-labs/ssr-dom-shim": 1.6.0
+
+    "@mdn/browser-compat-data@5.7.6": {}
+
+    "@mdn/browser-compat-data@6.1.5": {}
 
     "@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.7)":
         dependencies:
@@ -10534,6 +10654,10 @@ snapshots:
 
     assertion-error@2.0.1: {}
 
+    ast-metadata-inferer@0.8.1:
+        dependencies:
+            "@mdn/browser-compat-data": 5.7.6
+
     ast-types-flow@0.0.8: {}
 
     ast-types@0.16.1:
@@ -10564,6 +10688,8 @@ snapshots:
 
     baseline-browser-mapping@2.10.37: {}
 
+    baseline-browser-mapping@2.11.14: {}
+
     basic-auth@2.0.1:
         dependencies:
             safe-buffer: 5.1.2
@@ -10589,6 +10715,11 @@ snapshots:
         dependencies:
             fill-range: 7.1.1
 
+    browserslist-to-esbuild@2.1.1(browserslist@4.28.8):
+        dependencies:
+            browserslist: 4.28.8
+            meow: 13.2.0
+
     browserslist@4.28.2:
         dependencies:
             baseline-browser-mapping: 2.10.37
@@ -10596,6 +10727,14 @@ snapshots:
             electron-to-chromium: 1.5.372
             node-releases: 2.0.47
             update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+    browserslist@4.28.8:
+        dependencies:
+            baseline-browser-mapping: 2.11.14
+            caniuse-lite: 1.0.30001809
+            electron-to-chromium: 1.5.406
+            node-releases: 2.0.53
+            update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
     bundle-name@4.1.0:
         dependencies:
@@ -10646,6 +10785,8 @@ snapshots:
             upper-case: 1.1.3
 
     caniuse-lite@1.0.30001799: {}
+
+    caniuse-lite@1.0.30001809: {}
 
     chai-a11y-axe@1.5.0:
         dependencies:
@@ -10977,6 +11118,8 @@ snapshots:
 
     electron-to-chromium@1.5.372: {}
 
+    electron-to-chromium@1.5.406: {}
+
     emoji-regex@10.6.0: {}
 
     emoji-regex@8.0.0: {}
@@ -11199,6 +11342,17 @@ snapshots:
             eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5))(eslint@9.39.5)
         transitivePeerDependencies:
             - supports-color
+
+    eslint-plugin-compat@7.0.2(eslint@9.39.5):
+        dependencies:
+            "@mdn/browser-compat-data": 6.1.5
+            ast-metadata-inferer: 0.8.1
+            browserslist: 4.28.2
+            eslint: 9.39.5
+            find-up: 5.0.0
+            globals: 15.15.0
+            lodash.memoize: 4.1.2
+            semver: 7.8.4
 
     eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.5)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
         dependencies:
@@ -11539,6 +11693,8 @@ snapshots:
             path-is-absolute: 1.0.1
 
     globals@14.0.0: {}
+
+    globals@15.15.0: {}
 
     globals@16.4.0: {}
 
@@ -12163,6 +12319,8 @@ snapshots:
 
     lodash.debounce@4.0.8: {}
 
+    lodash.memoize@4.1.2: {}
+
     lodash.merge@4.6.2: {}
 
     log-update@4.0.0:
@@ -12237,6 +12395,8 @@ snapshots:
     mdn-data@2.27.1: {}
 
     media-typer@0.3.0: {}
+
+    meow@13.2.0: {}
 
     merge-stream@2.0.0: {}
 
@@ -12434,6 +12594,8 @@ snapshots:
             semver: 6.3.1
 
     node-releases@2.0.47: {}
+
+    node-releases@2.0.53: {}
 
     node@runtime:24.19.0: {}
 
@@ -13614,6 +13776,12 @@ snapshots:
     update-browserslist-db@1.2.3(browserslist@4.28.2):
         dependencies:
             browserslist: 4.28.2
+            escalade: 3.2.0
+            picocolors: 1.1.1
+
+    update-browserslist-db@1.3.1(browserslist@4.28.8):
+        dependencies:
+            browserslist: 4.28.8
             escalade: 3.2.0
             picocolors: 1.1.1
 

--- a/scripts/generate-compat-restrictions.mjs
+++ b/scripts/generate-compat-restrictions.mjs
@@ -1,0 +1,181 @@
+/**
+ * Generates the `no-restricted-properties` denylist used by eslint.config.mjs.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Our browser-compat guard has three layers:
+ *
+ *   1. Vite build target  -> guards SYNTAX (derived from browserslist)
+ *   2. TypeScript `lib`   -> guards ES BUILT-INS (Object.groupBy, Array#toSorted, ...)
+ *   3. eslint-plugin-compat -> guards WEB APIs
+ *
+ * Layer 3 has a systematic hole: its dataset (ast-metadata-inferer) does not
+ * emit AST nodes for *static* members. MDN's browser-compat-data names those
+ * with a `_static` suffix (`AbortSignal.timeout_static`, `URL.canParse_static`)
+ * and the inferer skips them entirely. The practical result is that
+ * `AbortSignal.timeout()` -- Safari 16, i.e. above our floor -- is not reported
+ * by any of the three layers.
+ *
+ * This script closes that hole by reading browser-compat-data directly and
+ * emitting a plain `no-restricted-properties` list for every static member that
+ * our browserslist floor does not support.
+ *
+ * The output is COMMITTED on purpose: it keeps lint fast (no 15MB JSON parse per
+ * run) and, more importantly, makes floor changes reviewable -- raising or
+ * lowering the floor shows up as an explicit diff of which APIs became legal.
+ *
+ * Regenerate with:  pnpm run generate:compat
+ * Run this whenever the "browserslist" key changes or BCD is upgraded.
+ */
+
+import bcd from "@mdn/browser-compat-data" with { type: "json" };
+import browserslist from "browserslist";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const OUT_PATH = fileURLToPath(
+    new URL("../eslint-compat-restrictions.generated.mjs", import.meta.url),
+);
+
+/**
+ * browserslist target id -> BCD browser id.
+ * Only browsers we actually care about enforcing; anything else in the
+ * browserslist result is ignored.
+ */
+const BROWSERSLIST_TO_BCD = {
+    safari: "safari",
+    ios_saf: "safari_ios",
+    chrome: "chrome",
+    edge: "edge",
+    firefox: "firefox",
+    and_chr: "chrome_android",
+    and_ff: "firefox_android",
+    samsung: "samsunginternet_android",
+};
+
+/** Compute the minimum supported version per BCD browser id from browserslist. */
+const getFloor = () => {
+    const floor = {};
+    for (const entry of browserslist()) {
+        const [name, rawVersion] = entry.split(" ");
+        const bcdName = BROWSERSLIST_TO_BCD[name];
+        if (!bcdName) continue;
+        // Ranges like "15.6-15.8" -> take the lower bound.
+        const version = parseFloat(rawVersion.split("-")[0]);
+        if (Number.isNaN(version)) continue;
+        if (floor[bcdName] === undefined || version < floor[bcdName]) {
+            floor[bcdName] = version;
+        }
+    }
+    return floor;
+};
+
+/**
+ * BCD support entries may be a single object or an array of historical ranges.
+ * Take the earliest still-current "version_added".
+ */
+const firstVersionAdded = (support) => {
+    if (!support) return undefined;
+    if (!Array.isArray(support)) return support.version_added;
+    const current = support.find((e) => e.version_added && !e.version_removed);
+    return (current ?? support[0])?.version_added;
+};
+
+/**
+ * Returns the list of floor browsers that do NOT support this API,
+ * or an empty array if every floor browser supports it.
+ */
+const findUnsupportedBrowsers = (support, floor) => {
+    const unsupported = [];
+    for (const [bcdName, minVersion] of Object.entries(floor)) {
+        const versionAdded = firstVersionAdded(support[bcdName]);
+        // Explicitly never supported.
+        if (versionAdded === false) {
+            unsupported.push(bcdName);
+            continue;
+        }
+        // No data at all -> treat as unsupported rather than silently allowing.
+        if (versionAdded === undefined || versionAdded === null) {
+            unsupported.push(bcdName);
+            continue;
+        }
+        // `true` means "supported, version unknown" -> assume ancient, allow.
+        if (versionAdded === true) continue;
+        const added = parseFloat(String(versionAdded).replace(/^≤/, ""));
+        if (Number.isNaN(added)) continue;
+        if (added > minVersion) unsupported.push(`${bcdName} ${versionAdded}`);
+    }
+    return unsupported;
+};
+
+const floor = getFloor();
+
+const restrictions = [];
+for (const [interfaceName, members] of Object.entries(bcd.api)) {
+    for (const [memberName, node] of Object.entries(members)) {
+        if (!memberName.endsWith("_static")) continue;
+        const support = node?.__compat?.support;
+        if (!support) continue;
+
+        const unsupported = findUnsupportedBrowsers(support, floor);
+        if (unsupported.length === 0) continue;
+
+        restrictions.push({
+            object: interfaceName,
+            property: memberName.replace(/_static$/, ""),
+            unsupported,
+        });
+    }
+}
+
+restrictions.sort(
+    (a, b) =>
+        a.object.localeCompare(b.object) ||
+        a.property.localeCompare(b.property),
+);
+
+const floorSummary = Object.entries(floor)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, version]) => `${name} ${version}`)
+    .join(", ");
+
+const body = restrictions
+    .map(
+        ({ object, property, unsupported }) =>
+            `    {\n` +
+            `        object: ${JSON.stringify(object)},\n` +
+            `        property: ${JSON.stringify(property)},\n` +
+            `        message:\n` +
+            `            ${JSON.stringify(
+                `${object}.${property} is above our browser floor (needs: ${unsupported.join(", ")}). See CONTRIBUTING.md.`,
+            )},\n` +
+            `    },`,
+    )
+    .join("\n");
+
+const output = `/**
+ * GENERATED FILE -- DO NOT EDIT BY HAND.
+ *
+ * Regenerate with: pnpm run generate:compat
+ * Source: scripts/generate-compat-restrictions.mjs
+ *
+ * Static Web API members that our supported browser floor does not implement.
+ * These are invisible to eslint-plugin-compat, whose dataset omits static
+ * members. See the script header for the full explanation.
+ *
+ * Browser floor at generation time: ${floorSummary}
+ * @mdn/browser-compat-data: ${bcd.__meta.version}
+ */
+
+/** @type {Array<{ object: string, property: string, message: string }>} */
+export const compatRestrictedProperties = [
+${body}
+];
+`;
+
+writeFileSync(OUT_PATH, output);
+
+console.log(
+    `Wrote ${restrictions.length} restricted static members to ${OUT_PATH}\n` +
+        `Browser floor: ${floorSummary}`,
+);


### PR DESCRIPTION
Hindre oss fra bruk av APIer som er ikke støttet av vår browser-targets.

Endringen i `vite.config.ts` fra `targets: 'es2022' til en ekte browserslist set betyr at disse CSS 'bugs' er nå fikset for free.

```
- .container (consent-banner.module.css:10) — loses inset-inline-start:50% + transform:translateX(-50%) at ≥48rem. Cookie banner container doesn't center on desktop. Cosmetic.
- .consentBanner (:29) — loses max-height:calc(100svh - 100px) + overflow-y:auto below 48rem. On small screens with long consent text the banner overflows the viewport with no scroll, so the accept/reject buttons can become unreachable. Functional.
- :global(.minimizedCookieBanner) (:39-47) — this one is fully dead, because its entire body is nested rules. .miniContent stays display:none and .content stays visible, so the minimize action produces no visual change. Functional.
- .content (:80), .dropdownMenuContainer (@media(min-height:0dvh) dvh feature-probe) — padding/height fallbacks lost. Cosmetic.
- 2 & rules — .text:last-of-type{margin-bottom:0} and an ellipsis :after animation lost. Cosmetic.

So: 2 functional regressions (mobile consent-banner scroll, minimize toggle), rest cosmetic — all on Safari <16.5 / Chrome <112 / Firefox <117.
```