### PR TITLE
Rydd opp i bruk av aria på egendefinerte rot-elementer

### DIFF
--- a/packages/client/src/views/dropdown-menu.ts
+++ b/packages/client/src/views/dropdown-menu.ts
@@ -58,6 +58,7 @@ class DropdownMenu extends HTMLElement {
         this.button = this.querySelector(":scope > button")!;
         this.button.addEventListener("click", () => this.toggle());
         this.menuType = this.getAttribute("menu-type") as MenuType;
+        this.button.setAttribute("aria-expanded", "false");
         window.addEventListener("click", this.handleWindowClick);
         window.addEventListener("closemenus", this.close);
         window.addEventListener("keydown", this.handleButtonClick);

--- a/packages/client/src/views/ops-messages.ts
+++ b/packages/client/src/views/ops-messages.ts
@@ -1,5 +1,6 @@
 import cls from "decorator-client/src/styles/ops-messages.module.css";
 import utils from "decorator-client/src/styles/utils.module.css";
+import i18n from "decorator-client/src/views/i18n";
 import {
     ExclamationmarkTriangleIcon,
     InformationSquareIcon,
@@ -38,33 +39,30 @@ export const OpsMessagesTemplate = ({
     opsMessages,
 }: {
     opsMessages: OpsMessage[];
-}) => {
-    const ariaLabel = window.__DECORATOR_DATA__.texts.important_info;
-    return html`
-        <section
-            class="${cls.opsMessagesContent} ${utils.contentContainer}"
-            aria-label="${ariaLabel}"
-        >
-            ${opsMessages.map(({ heading, url, type }) => {
-                const fullUrl = checkAndCorrectHost(url);
-                return html`
-                    <a href="${fullUrl}" class="${cls.opsMessage}">
-                        ${
-                            type === "prodstatus"
-                                ? ExclamationmarkTriangleIcon({
-                                      className: utils.icon,
-                                  })
-                                : InformationSquareIcon({
-                                      className: utils.icon,
-                                  })
-                        }
-                        ${heading}
-                    </a>
-                `;
-            })}
-        </section>
-    `;
-};
+}) => html`
+    <section
+        class="${cls.opsMessagesContent} ${utils.contentContainer}"
+        aria-label="${i18n("important_info")}"
+    >
+        ${opsMessages.map(({ heading, url, type }) => {
+            const fullUrl = checkAndCorrectHost(url);
+            return html`
+                <a href="${fullUrl}" class="${cls.opsMessage}">
+                    ${
+                        type === "prodstatus"
+                            ? ExclamationmarkTriangleIcon({
+                                  className: utils.icon,
+                              })
+                            : InformationSquareIcon({
+                                  className: utils.icon,
+                              })
+                    }
+                    ${heading}
+                </a>
+            `;
+        })}
+    </section>
+`;
 
 // If the scoped url of a message ends with a literal "$"
 // it should only be shown on that exact url

--- a/packages/client/src/views/ops-messages.ts
+++ b/packages/client/src/views/ops-messages.ts
@@ -38,21 +38,33 @@ export const OpsMessagesTemplate = ({
     opsMessages,
 }: {
     opsMessages: OpsMessage[];
-}) => html`
-    <section class="${cls.opsMessagesContent} ${utils.contentContainer}">
-        ${opsMessages.map(({ heading, url, type }) => {
-            const fullUrl = checkAndCorrectHost(url);
-            return html`
-                <a href="${fullUrl}" class="${cls.opsMessage}">
-                    ${type === "prodstatus"
-                        ? ExclamationmarkTriangleIcon({ className: utils.icon })
-                        : InformationSquareIcon({ className: utils.icon })}
-                    ${heading}
-                </a>
-            `;
-        })}
-    </section>
-`;
+}) => {
+    const ariaLabel = window.__DECORATOR_DATA__.texts.important_info;
+    return html`
+        <section
+            class="${cls.opsMessagesContent} ${utils.contentContainer}"
+            aria-label="${ariaLabel}"
+        >
+            ${opsMessages.map(({ heading, url, type }) => {
+                const fullUrl = checkAndCorrectHost(url);
+                return html`
+                    <a href="${fullUrl}" class="${cls.opsMessage}">
+                        ${
+                            type === "prodstatus"
+                                ? ExclamationmarkTriangleIcon({
+                                      className: utils.icon,
+                                  })
+                                : InformationSquareIcon({
+                                      className: utils.icon,
+                                  })
+                        }
+                        ${heading}
+                    </a>
+                `;
+            })}
+        </section>
+    `;
+};
 
 // If the scoped url of a message ends with a literal "$"
 // it should only be shown on that exact url
@@ -105,15 +117,9 @@ class OpsMessages extends HTMLElement {
         );
 
         if (filteredMessages.length === 0) {
-            this.removeAttribute("aria-label");
             this.innerHTML = "";
             return;
         }
-
-        this.setAttribute(
-            "aria-label",
-            window.__DECORATOR_DATA__.texts.important_info,
-        );
 
         this.innerHTML = OpsMessagesTemplate({
             opsMessages: filteredMessages,

--- a/packages/server/src/views/dropdown-menu.ts
+++ b/packages/server/src/views/dropdown-menu.ts
@@ -19,7 +19,7 @@ export const DropdownMenu = ({
     dropdownClass,
     attributes = {},
 }: DropdownMenuProps) => html`
-    <dropdown-menu ${htmlAttributes(attributes)} aria-expanded="false">
+    <dropdown-menu ${htmlAttributes(attributes)}>
         ${button}
         <div class="${clsx(cls.dropdownMenuContainer, dropdownClass)}">
             ${dropdownContent}


### PR DESCRIPTION
1. Fjerner aria-expanded på dropdown-meny (håndteres på button)
2. Flytter aria-label til section i ops-messages

Jeg har testet lokalt og på dev2