### PR TITLE
chore: raskere bygg, særlig icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,5 +1282,3 @@ hjelpefunksjoner for enkel håndtering av samtykke. Den tilbyr også hjelpefunks
 lese cookies, som sikrer at kun tillatte cookies kan settes.
 
 </details>
-
-ok

--- a/README.md
+++ b/README.md
@@ -1282,3 +1282,5 @@ hjelpefunksjoner for enkel håndtering av samtykke. Den tilbyr også hjelpefunks
 lese cookies, som sikrer at kun tillatte cookies kan settes.
 
 </details>
+
+ok

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint:next": "pnpm --filter next-pages-router-example run lint",
         "dev": "concurrently \"pnpm --filter decorator-client run dev\" \"pnpm --filter decorator-server run dev\"",
         "example": "pnpm --filter next-pages-router-example run dev",
-        "build": "pnpm --filter decorator-icons run build && pnpm --filter decorator-client run build && pnpm --filter decorator-server run build && pnpm run copy-assets",
+        "build": "pnpm -r --filter='decorator-*' run build && pnpm run copy-assets",
         "copy-assets": "mkdir -p packages/server/public && copyfiles -u 3 packages/client/dist/assets/**/* packages/server/public/",
         "prepare": "husky",
         "benchmarking": "./benchmarking/run",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "scripts": {
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
-        "test": "pnpm -r run test",
-        "lint": "pnpm -r run lint",
+        "test": "pnpm -r --parallel run test",
+        "lint": "pnpm -r --parallel run lint",
         "lint:client": "pnpm --filter decorator-client run lint",
         "lint:server": "pnpm --filter decorator-server run lint",
         "lint:icons": "pnpm --filter decorator-icons run lint",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "pnpm run build-main && pnpm run build-csr",
+        "build": "vite build --mode main && vite build --mode csr",
         "build:watch": "vite build --watch --mode main",
         "build-main": "vite build --mode main",
         "build-csr": "vite build --mode csr",

--- a/packages/icons/build-icons.ts
+++ b/packages/icons/build-icons.ts
@@ -6,8 +6,10 @@ import {
     rmSync,
     writeFileSync,
 } from "node:fs";
+import type { Config } from "svgo";
 import { writeFile } from "node:fs/promises";
 import { enableCompileCache } from "node:module";
+import { basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Cache V8 compilation of the svgo module graph, which is imported lazily below.
@@ -15,13 +17,14 @@ enableCompileCache();
 
 const DIST = "./dist";
 const SRC = "./src";
+const SVG_EXT = ".svg";
 const MANIFEST_FILE = ".build-manifest.json";
 
 const readUtf8 = (path: string) => readFileSync(path, "utf-8");
 
 const localSvgNames = readdirSync(SRC)
-    .filter((file) => file.endsWith(".svg"))
-    .map((file) => file.slice(0, -4))
+    .filter((file) => file.endsWith(SVG_EXT))
+    .map((file) => basename(file, SVG_EXT))
     .sort();
 
 /**
@@ -99,7 +102,7 @@ const svgoConfig = {
     // Pretty-printing costs nothing measurable here and keeps the generated
     // files readable without running a JS formatter over them.
     js2svg: { pretty: true, indent: 2 },
-};
+} satisfies Config;
 
 const jsString =
     '${htmlAttributes({ ariaHidden: ariaLabel ? "false" : "true", ...props })} ${ariaLabel ? html`aria-label="${ariaLabel}"` : ""}';
@@ -141,11 +144,13 @@ await Promise.all(
     ),
 );
 
-// Drop files left behind by earlier builds, e.g. icons removed upstream.
+// Every file this build is responsible for, including the manifest itself.
 const expectedFiles = new Set([
     ...generated.map(({ file }) => file),
     MANIFEST_FILE,
 ]);
+
+// Drop files left behind by earlier builds, e.g. icons removed upstream.
 for (const file of readdirSync(DIST)) {
     if (!expectedFiles.has(file)) {
         rmSync(`${DIST}/${file}`, { recursive: true, force: true });
@@ -154,5 +159,5 @@ for (const file of readdirSync(DIST)) {
 
 writeFileSync(
     `${DIST}/${MANIFEST_FILE}`,
-    JSON.stringify({ hash: expectedHash, fileCount: generated.length + 1 }),
+    JSON.stringify({ hash: expectedHash, fileCount: expectedFiles.size }),
 );

--- a/packages/icons/build-icons.ts
+++ b/packages/icons/build-icons.ts
@@ -1,85 +1,158 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import * as prettier from "prettier";
-import metadata from "@navikt/aksel-icons/metadata";
-import { optimize } from "svgo";
-import { glob } from "glob";
+import { createHash } from "node:crypto";
+import {
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { enableCompileCache } from "node:module";
 import { fileURLToPath } from "node:url";
 
-mkdirSync("./dist", { recursive: true });
+// Cache V8 compilation of the svgo module graph, which is imported lazily below.
+enableCompileCache();
 
-const svgFiles = await glob("./src/*.svg");
+const DIST = "./dist";
+const SRC = "./src";
+const MANIFEST_FILE = ".build-manifest.json";
 
-const files = svgFiles.map((filePath) => {
-    // Prevent build errors on windows file systems
-    const unixPath = filePath.replaceAll("\\", "/");
-    return {
-        name: /([^/]+)\.svg$/.exec(unixPath)?.[1] ?? "wat",
-        path: unixPath,
-    };
-});
+const readUtf8 = (path: string) => readFileSync(path, "utf-8");
+
+const localSvgNames = readdirSync(SRC)
+    .filter((file) => file.endsWith(".svg"))
+    .map((file) => file.slice(0, -4))
+    .sort();
+
+/**
+ * Content hash of everything that can change the generated output. Computed
+ * before svgo and the icon metadata are imported, so an up-to-date `dist`
+ * costs nothing beyond process startup.
+ */
+const inputHash = () => {
+    const akselPackage = fileURLToPath(
+        import.meta.resolve("@navikt/aksel-icons/package.json"),
+    );
+    const hash = createHash("sha256");
+    hash.update(JSON.parse(readUtf8(akselPackage)).version);
+    hash.update(readUtf8("./package.json"));
+    hash.update(readUtf8(fileURLToPath(import.meta.url)));
+    hash.update(readUtf8(`${SRC}/types.ts`));
+    for (const name of localSvgNames) {
+        hash.update(name);
+        hash.update(readUtf8(`${SRC}/${name}.svg`));
+    }
+    return hash.digest("hex");
+};
+
+const expectedHash = inputHash();
+
+const isUpToDate = () => {
+    try {
+        const manifest = JSON.parse(readUtf8(`${DIST}/${MANIFEST_FILE}`));
+        return (
+            manifest.hash === expectedHash &&
+            manifest.fileCount === readdirSync(DIST).length
+        );
+    } catch {
+        return false;
+    }
+};
+
+if (isUpToDate()) {
+    process.exit(0);
+}
+
+const [{ optimize }, { default: metadata }] = await Promise.all([
+    import("svgo"),
+    import("@navikt/aksel-icons/metadata"),
+]);
+
+const akselNames = Object.keys(metadata);
+
+// Resolve the aksel svg directory once rather than once per icon.
+const akselSvgDir = fileURLToPath(
+    new URL(
+        ".",
+        import.meta.resolve(`@navikt/aksel-icons/svg/${akselNames[0]}.svg`),
+    ),
+);
+
+const icons = [
+    ...akselNames.map((name) => ({ name, path: `${akselSvgDir}${name}.svg` })),
+    ...localSvgNames.map((name) => ({ name, path: `${SRC}/${name}.svg` })),
+];
+
+const svgoConfig = {
+    plugins: [
+        "preset-default",
+        {
+            name: "addAttributesToSVGElement",
+            params: {
+                attribute: {
+                    focusable: "false",
+                    role: "img",
+                },
+            },
+        },
+    ],
+    // Pretty-printing costs nothing measurable here and keeps the generated
+    // files readable without running a JS formatter over them.
+    js2svg: { pretty: true, indent: 2 },
+};
+
 const jsString =
     '${htmlAttributes({ ariaHidden: ariaLabel ? "false" : "true", ...props })} ${ariaLabel ? html`aria-label="${ariaLabel}"` : ""}';
 
-const fileTemplate = ({ svg, name }: { svg: string; name: string }) => `
-import html, { htmlAttributes } from "decorator-shared/html";
+const fileTemplate = ({ svg, name }: { svg: string; name: string }) =>
+    `import html, { htmlAttributes } from "decorator-shared/html";
 import type { IconProps } from "./types";
 
-export const ${name}Icon = ({ ariaLabel, ...props}: IconProps = {}) => html\`
-${svg}
-\`;
+export const ${name}Icon = ({ ariaLabel, ...props }: IconProps = {}) => html\`
+${svg}\`;
 `;
 
-await Promise.all(
-    [
-        ...Object.keys(metadata).map((name) => ({
+mkdirSync(DIST, { recursive: true });
+
+const generated = icons.map(({ name, path }) => {
+    const { data } = optimize(readUtf8(path), svgoConfig);
+    return {
+        file: `${name}.ts`,
+        contents: fileTemplate({
+            svg: data.replace("<svg", `<svg ${jsString}`),
             name,
-            path: `@navikt/aksel-icons/svg/${name}.svg`,
-        })),
-        ...files,
-    ].map(async ({ name, path }) => {
-        const iconPath = path.startsWith("@")
-            ? fileURLToPath(import.meta.resolve(path))
-            : path;
-        const icon = readFileSync(iconPath, "utf-8");
-        const result = optimize(icon, {
-            path: iconPath,
-            plugins: [
-                "preset-default",
-                {
-                    name: "addAttributesToSVGElement",
-                    params: {
-                        attribute: {
-                            focusable: "false",
-                            role: "img",
-                        },
-                    },
-                },
-            ],
-        });
+        }),
+    };
+});
 
-        const optimizedSvgString = result.data;
-
-        writeFileSync(
-            `./dist/${name}.ts`,
-            await prettier.format(
-                fileTemplate({
-                    svg: optimizedSvgString.replace("<svg", `<svg ${jsString}`),
-                    name,
-                }),
-                { filepath: `${name}.ts` },
-            ),
-        );
-    }),
+generated.push(
+    {
+        file: "index.ts",
+        contents: `export * from "../src";\n${icons
+            .map(({ name }) => `export * from "./${name}";`)
+            .join("\n")}\n`,
+    },
+    { file: "types.ts", contents: readUtf8(`${SRC}/types.ts`) },
 );
+
+await Promise.all(
+    generated.map(({ file, contents }) =>
+        writeFile(`${DIST}/${file}`, contents),
+    ),
+);
+
+// Drop files left behind by earlier builds, e.g. icons removed upstream.
+const expectedFiles = new Set([
+    ...generated.map(({ file }) => file),
+    MANIFEST_FILE,
+]);
+for (const file of readdirSync(DIST)) {
+    if (!expectedFiles.has(file)) {
+        rmSync(`${DIST}/${file}`, { recursive: true, force: true });
+    }
+}
 
 writeFileSync(
-    "./dist/index.ts",
-    `
-export * from '../src';
-${[...Object.keys(metadata), ...files.map(({ name }) => name)]
-    .map((name) => `export * from "./${name}";`)
-    .join("\n")}
-`,
+    `${DIST}/${MANIFEST_FILE}`,
+    JSON.stringify({ hash: expectedHash, fileCount: generated.length + 1 }),
 );
-
-writeFileSync("./dist/types.ts", readFileSync("./src/types.ts", "utf-8"));

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -6,7 +6,7 @@
         ".": "./dist/index.ts"
     },
     "scripts": {
-        "build": "tsx build-icons.ts",
+        "build": "node build-icons.ts",
         "lint": "eslint . && tsc --noEmit"
     },
     "dependencies": {
@@ -14,8 +14,6 @@
     },
     "devDependencies": {
         "@navikt/aksel-icons": "8.16.1",
-        "glob": "13.0.6",
-        "svgo": "4.0.2",
-        "tsx": "catalog:"
+        "svgo": "4.0.2"
     }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,8 +8,8 @@
         "postinstall": "cp .env.sample .env",
         "serve": "NODE_ENV=production node dist/server.js",
         "serve-local": "NODE_ENV=production APP_URL=http://localhost:8089 tsx --import ./css-module-register.ts --env-file=.env --watch src/server.ts",
-        "clean": "rm -rf ./public/assets",
-        "build": "pnpm run clean && NODE_ENV=production tsx build.ts",
+        "prebuild": "rm -rf ./public/assets",
+        "build": "NODE_ENV=production tsx build.ts",
         "test": "vitest run",
         "lint": "eslint . && tsc --noEmit"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,15 +175,9 @@ importers:
             "@navikt/aksel-icons":
                 specifier: 8.16.1
                 version: 8.16.1
-            glob:
-                specifier: 13.0.6
-                version: 13.0.6
             svgo:
                 specifier: 4.0.2
                 version: 4.0.2
-            tsx:
-                specifier: "catalog:"
-                version: 4.23.1
 
     packages/next-pages-router-example:
         dependencies:


### PR DESCRIPTION
- Slippe prettier og glob fra icons-build script - behold *noe* 'prettiness'
    - IMO hvis man trenger kjempe-pretty output, er det lett å kjøre `prettier` på en fil - men vi nesten aldri se på disse filene.
- Legg til en cache, 'warm' bygger er nå kjempefort
- Forbedre command-pipelines (avoid loops where we call `pnpm` from within a `pnpm` process needlessly).
- Kjøre rot/monorepo kommandoer med `parallel`

# Output sammenligning

*Før*

```ts
export const AirplaneIcon = ({ ariaLabel, ...props }: IconProps = {}) => html`
  <svg
    ${htmlAttributes({ ariaHidden: ariaLabel ? "false" : "true", ...props })}
    ${ariaLabel ? html`aria-label="${ariaLabel}"` : ""}
    xmlns="http://www.w3.org/2000/svg"
    width="1em"
    height="1em"
    fill="none"
    viewBox="0 0 24 24"
    focusable="false"
    role="img"
  >
    <path
      fill="currentColor"
      fill-rule="evenodd"
      d="M6.388 3.625a.75.75 0 0 0-.412 1.145l2.392 3.489-.255.073-2.318-1.643a.75.75 0 0 0-.64-.11l-1.923.552a.75.75 0 0 0-.33 1.244l3.07 3.147a5.75 5.75 0 0 0 5.7 1.51l8.665-2.484c.99-.284 1.231-1.576.41-2.198l-1.594-1.207a4.75 4.75 0 0 0-4.177-.779l-1.547.444-4.44-3.596a.75.75 0 0 0-.678-.138zM8.18 9.873l1.082-.31.29.423a.75.75 0 0 0 1.238-.848L7.802 4.78l.547-.157 4.44 3.596a.75.75 0 0 0 .678.138l1.922-.551a3.25 3.25 0 0 1 2.858.533l1.196.905-8.184 2.347a4.25 4.25 0 0 1-4.213-1.117L4.853 8.226l.369-.105 2.317 1.643a.75.75 0 0 0 .641.11m1.63 7.566-.096-.104c.759-.67 2.107-1.585 3.786-1.585 3.086 0 4.75 2.164 4.75 4.25a.75.75 0 0 0 1.5 0c0-2.914-2.336-5.75-6.25-5.75-2.452 0-4.275 1.458-5.083 2.242A4.1 4.1 0 0 0 7 16.25c-1.204 0-2.161.459-2.81 1.19-.638.716-.94 1.65-.94 2.56a.75.75 0 0 0 1.5 0c0-.59.198-1.156.56-1.564.351-.395.894-.686 1.69-.686s1.339.291 1.69.686c.362.408.56.974.56 1.564a.75.75 0 0 0 1.5 0c0-.91-.302-1.844-.94-2.56"
      clip-rule="evenodd"
    />
  </svg>
`;
```

*Etter*

```ts
export const AirplaneIcon = ({ ariaLabel, ...props }: IconProps = {}) => html`
<svg ${htmlAttributes({ ariaHidden: ariaLabel ? "false" : "true", ...props })} ${ariaLabel ? html`aria-label="${ariaLabel}"` : ""} xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="none" viewBox="0 0 24 24" focusable="false" role="img">
  <path fill="currentColor" fill-rule="evenodd" d="M6.388 3.625a.75.75 0 0 0-.412 1.145l2.392 3.489-.255.073-2.318-1.643a.75.75 0 0 0-.64-.11l-1.923.552a.75.75 0 0 0-.33 1.244l3.07 3.147a5.75 5.75 0 0 0 5.7 1.51l8.665-2.484c.99-.284 1.231-1.576.41-2.198l-1.594-1.207a4.75 4.75 0 0 0-4.177-.779l-1.547.444-4.44-3.596a.75.75 0 0 0-.678-.138zM8.18 9.873l1.082-.31.29.423a.75.75 0 0 0 1.238-.848L7.802 4.78l.547-.157 4.44 3.596a.75.75 0 0 0 .678.138l1.922-.551a3.25 3.25 0 0 1 2.858.533l1.196.905-8.184 2.347a4.25 4.25 0 0 1-4.213-1.117L4.853 8.226l.369-.105 2.317 1.643a.75.75 0 0 0 .641.11m1.63 7.566-.096-.104c.759-.67 2.107-1.585 3.786-1.585 3.086 0 4.75 2.164 4.75 4.25a.75.75 0 0 0 1.5 0c0-2.914-2.336-5.75-6.25-5.75-2.452 0-4.275 1.458-5.083 2.242A4.1 4.1 0 0 0 7 16.25c-1.204 0-2.161.459-2.81 1.19-.638.716-.94 1.65-.94 2.56a.75.75 0 0 0 1.5 0c0-.59.198-1.156.56-1.564.351-.395.894-.686 1.69-.686s1.339.291 1.69.686c.362.408.56.974.56 1.564a.75.75 0 0 0 1.5 0c0-.91-.302-1.844-.94-2.56" clip-rule="evenodd"/>
</svg>
`;
```